### PR TITLE
refactor(MCF-7): refactor Summarized to explicit chain steps

### DIFF
--- a/.kiro/specs/contextforge/design.md
+++ b/.kiro/specs/contextforge/design.md
@@ -41,13 +41,13 @@ graph LR
     end
     subgraph "Application Layer"
         SVC["ContextService (Facade)"]
-        UC1["ReadFullUseCase"]
-        UC2["ReadSummarizeUseCase"]
-        UC3["ReadChunksUseCase"]
+        subgraph "services/"
+            RS["ReadSummarizeUseCase"]
+        end
     end
     subgraph "Domain Layer"
         E["Entities (ContextItem, Chunk, CacheEntry, ProviderConfig, SessionConfig, LLMConfig)"]
-        P["Ports / Interfaces (ProviderInterface, CacheRepositoryInterface, LLMEngineInterface)"]
+        P["Ports / Interfaces (ProviderInterface, CacheRepositoryInterface, LLMEngineInterface, SummarizeEngineInterface)"]
         EX["Domain Exceptions"]
     end
     subgraph "Infrastructure Layer"
@@ -65,6 +65,7 @@ graph LR
         end
         CH["ChromaCacheRepository"]
         GE["GeminiLLMEngine"]
+        SUM["Summarized"]
         LF["LLMFactory"]
         CB["ContextItemBuilder"]
         CEB["CacheEntryBuilder"]
@@ -73,20 +74,18 @@ graph LR
     MAIN --> ROUTES
     ROUTES --> CTRL
     CTRL --> SVC
-    SVC --> UC1
-    SVC --> UC2
-    SVC --> UC3
-    UC1 --> P
-    UC2 --> P
-    UC3 --> P
+    SVC --> RS
+    RS --> P
     YT --> P
     GH --> P
     GL --> P
     PDF --> P
     MD --> P
     CH --> P
-    GE --> P
+    GE -.->|".llm, .embeddings"| SUM
+    SUM --> P
     LF --> GE
+    LF --> SUM
     CB --> E
     CEB --> E
 ```
@@ -98,7 +97,7 @@ graph LR
 | **S** - Single Responsibility | Cada caso de uso tiene una única responsabilidad (leer, resumir, fragmentar). Cada controller maneja un único endpoint MCP. |
 | **O** - Open/Closed | `ProviderFactory` y `LLMFactory` permiten agregar implementaciones sin modificar código existente |
 | **L** - Liskov Substitution | `YouTrackProvider` y `JiraProvider` son intercambiables vía `ProviderInterface` |
-| **I** - Interface Segregation | Interfaces separadas para proveedor (`ProviderInterface`), caché (`CacheRepositoryInterface`) y motor LLM (`LLMEngineInterface`) |
+| **I** - Interface Segregation | Interfaces separadas para proveedor (`ProviderInterface`), caché (`CacheRepositoryInterface`), motor LLM (`LLMEngineInterface`) y summarization (`SummarizeEngineInterface`) |
 | **D** - Dependency Inversion | Los casos de uso dependen de interfaces, no de implementaciones concretas |
 
 ---
@@ -488,6 +487,7 @@ class SessionConfig:
 class LLMConfig:
     engine_type: str   # "gemini", "openai", etc.
     api_key: str
+    model_version: str = "gemini-2.5-flash-lite"  # modelo por defecto
 
 @dataclass
 class ContextItem:
@@ -552,6 +552,16 @@ class CacheRepositoryInterface(ABC):
     def invalidate(self, item_id: str, provider_name: str, tool: str) -> None: ...
 
 class LLMEngineInterface(ABC):
+    @property
+    @abstractmethod
+    def llm(self) -> ChatGoogleGenerativeAI: ...
+
+    @property
+    @abstractmethod
+    def embeddings(self) -> GoogleGenerativeAIEmbeddings: ...
+
+
+class SummarizeEngineInterface(ABC):
     @abstractmethod
     def summarize(self, content: str, max_tokens: int) -> str: ...
 
@@ -624,24 +634,27 @@ provider = factory.create()
 
 ## Infrastructure Layer: LLMFactory
 
-El `LLMFactory` es un factory simple que instancia el motor correcto según `engine_type` de `LLMConfig`. No requiere registro previo.
+El `LLMFactory` es un factory simple que instancia el motor correcto según `engine_type` de `LLMConfig`. Crea internamente `GeminiLLMEngine` y `Summarized`, retornando este último que implementa `SummarizeEngineInterface`.
 
 ```python
 # src/infrastructure/llm/factory.py
 from src.domain.entities import LLMConfig
 from src.domain.exceptions import LLMEngineNotRegisteredError
-from src.domain.interfaces import LLMEngineInterface
+from src.domain.interfaces import SummarizeEngineInterface
 from src.infrastructure.llm.gemini import GeminiLLMEngine
+from src.infrastructure.llm.prompts import SUMMARIZE_PROMPT
+from src.infrastructure.llm.summarized import Summarized
 
 
 class LLMFactory:
     def __init__(self, config: LLMConfig) -> None:
         self.config = config
 
-    def create(self) -> LLMEngineInterface:
+    def create(self) -> SummarizeEngineInterface:
         engine_type = self.config.engine_type
         if engine_type == "gemini":
-            return GeminiLLMEngine(self.config)
+            engine_llm = GeminiLLMEngine(self.config)
+            return Summarized(engine_llm, SUMMARIZE_PROMPT)
         raise LLMEngineNotRegisteredError(
             f"Motor LLM '{engine_type}' no reconocido. Disponibles: gemini"
         )
@@ -653,7 +666,7 @@ class LLMFactory:
 # Uso simple - engine_type determina qué motor instanciar
 config = LLMConfig(engine_type="gemini", api_key="xxx")
 factory = LLMFactory(config)
-engine = factory.create()
+summarized = factory.create()  # Retorna Summarized (SummarizeEngineInterface)
 ```
 
 ---
@@ -766,37 +779,44 @@ class ReadFullUseCase:
 ```
 
 ```python
-# src/application/use_cases/read_summarize.py
+# src/application/services/read_summarize.py
 from datetime import datetime, timezone
-from ...domain.interfaces import ProviderInterface, CacheRepositoryInterface, LLMEngineInterface
-from ...domain.entities import CacheEntry
-from ...domain.exceptions import ValidationError
-from ...infrastructure.builders.cache_entry import CacheEntryBuilder
+from src.domain.interfaces import CacheRepositoryInterface, ProviderInterface, SummarizeEngineInterface
+from src.domain.entities import CacheEntry
+from src.domain.exceptions import ValidationError
+from src.infrastructure.builders.cache_entry import CacheEntryBuilder
+
 
 class ReadSummarizeUseCase:
-    def __init__(self, provider: ProviderInterface, cache: CacheRepositoryInterface, llm: LLMEngineInterface):
+    def __init__(
+        self,
+        provider: ProviderInterface,
+        cache: CacheRepositoryInterface,
+        summarized: SummarizeEngineInterface,
+    ) -> None:
         self._provider = provider
         self._cache = cache
-        self._llm = llm
+        self._summarized = summarized
 
-    def execute(self, item_id: str, provider_name: str, max_tokens: int = 500) -> CacheEntry:
+    def execute(
+        self,
+        item_id: str,
+        provider_name: str,
+        max_tokens: int = 500,
+    ) -> CacheEntry:
         if not (1 <= max_tokens <= 10000):
             raise ValidationError("max_tokens debe estar entre 1 y 10000")
 
-        # 1. PRIMERO: Ir al proveedor para obtener contenido fresco
         item = self._provider.get_item(item_id, self._provider._config)
 
-        # 2. Buscar en caché por content_hash + tool + max_tokens
         cached = self._cache.lookup(
             item_id, provider_name, item.content_hash, "read_summarize", max_tokens=max_tokens
         )
         if cached:
             return cached
 
-        # 3. CACHE MISS: Generar resumen con LLM
-        summary = self._llm.summarize(item.raw_content, max_tokens)
+        summary = self._summarized.summarize(item.raw_content, max_tokens)
 
-        # 4. Guardar en caché
         entry = (
             CacheEntryBuilder()
             .for_item(item)
@@ -1166,20 +1186,21 @@ Los prompts se definen como constantes reutilizables usando `ChatPromptTemplate.
 # src/infrastructure/llm/prompts.py
 from langchain_core.prompts import ChatPromptTemplate
 
-# Prompt para read_summarize: rol system fija el comportamiento, rol human aporta el contenido dinámico
 SUMMARIZE_PROMPT = ChatPromptTemplate.from_messages([
     (
         "system",
-        (
-            "Eres un asistente técnico experto en resumir ítems de gestión de proyectos. "
-            "Tu tarea es extraer los puntos más importantes del ítem proporcionado. "
-            "El resumen debe ser conciso, preciso y no superar {max_tokens} tokens. "
-            "Responde únicamente con el resumen, sin encabezados ni explicaciones adicionales."
-        ),
+        """Eres un asistente técnico especializado en resumir contenido de manera concisa y precisa.
+
+Reglas:
+- Máximo {max_tokens} tokens
+- Incluir solo información relevante y verificable
+- Mantener claridad y estructura
+- No inventar ni añadir información no presente en el contenido original
+- Priorizar: problema, contexto, estado actual, puntos clave""",
     ),
     (
         "human",
-        "Resume el siguiente ítem:\n\n{content}",
+        "Contenido a resumir:\n\n{content}",
     ),
 ])
 ```
@@ -1188,47 +1209,75 @@ SUMMARIZE_PROMPT = ChatPromptTemplate.from_messages([
 
 ## Infrastructure Layer: GeminiLLMEngine
 
-Usa **LCEL** (LangChain Expression Language) con el operador pipe `|` para componer la chain: `prompt | llm | StrOutputParser()`. El `ChatPromptTemplate` con roles `system`/`human` es el patrón recomendado para producción. `get_num_tokens()` usa el tokenizador nativo del modelo vía `langchain_google_genai`.
+Implementa `LLMEngineInterface`, exponiendo `.llm` y `.embeddings` para que `Summarized` los use internamente.
 
 ```python
 # src/infrastructure/llm/gemini.py
 from langchain_google_genai import ChatGoogleGenerativeAI, GoogleGenerativeAIEmbeddings
-from langchain_core.output_parsers import StrOutputParser
-from ...domain.interfaces import LLMEngineInterface
-from ...domain.entities import LLMConfig
-from ...domain.exceptions import LLMError
-from .prompts import SUMMARIZE_PROMPT
+
+from src.domain.entities import LLMConfig
+from src.domain.interfaces import LLMEngineInterface
+
 
 class GeminiLLMEngine(LLMEngineInterface):
-    def __init__(self, config: LLMConfig):
+    def __init__(self, config: LLMConfig) -> None:
+        self._config = config
         self._llm = ChatGoogleGenerativeAI(
-            model="gemini-2.0-flash",
+            model=config.model_version,
             google_api_key=config.api_key,
         )
         self._embeddings = GoogleGenerativeAIEmbeddings(
             model="models/text-embedding-004",
             google_api_key=config.api_key,
         )
-        # Chain LCEL: ChatPromptTemplate | LLM | StrOutputParser
-        # StrOutputParser extrae el string del AIMessage automáticamente
-        self._summarize_chain = SUMMARIZE_PROMPT | self._llm | StrOutputParser()
+
+    @property
+    def llm(self) -> ChatGoogleGenerativeAI:
+        return self._llm
+
+    @property
+    def embeddings(self) -> GoogleGenerativeAIEmbeddings:
+        return self._embeddings
+```
+
+---
+
+## Infrastructure Layer: Summarized
+
+Implementa `SummarizeEngineInterface`. Recibe un `LLMEngineInterface` y el template de prompt, construye la chain LCEL internamente.
+
+```python
+# src/infrastructure/llm/summarized.py
+from langchain_core.output_parsers import StrOutputParser
+from langchain_core.prompts import ChatPromptTemplate
+
+from src.domain.exceptions import LLMError
+from src.domain.interfaces import LLMEngineInterface, SummarizeEngineInterface
+
+
+class Summarized(SummarizeEngineInterface):
+    def __init__(
+        self,
+        engine_llm: LLMEngineInterface,
+        prompt_template: ChatPromptTemplate,
+    ) -> None:
+        self._llm = engine_llm.llm
+        self._embeddings = engine_llm.embeddings
+        self._chain = prompt_template | self._llm | StrOutputParser()
 
     def summarize(self, content: str, max_tokens: int) -> str:
-        """Genera resumen usando LCEL chain. El prompt usa roles system/human explícitos."""
         try:
-            return self._summarize_chain.invoke({
+            return self._chain.invoke({
                 "content": content,
                 "max_tokens": max_tokens,
             })
         except Exception as e:
-            raise LLMError(f"Error al generar resumen con Gemini: {e}") from e
+            raise LLMError(f"Error al generar resumen: {e}") from e
 
     def count_tokens(self, text: str) -> int:
-        """Cuenta tokens usando el tokenizador nativo del modelo."""
         return self._llm.get_num_tokens(text)
 
     def get_embeddings(self, text: str) -> list[float]:
-        """Genera embeddings para almacenamiento en ChromaDB."""
         return self._embeddings.embed_query(text)
 ```
 

--- a/.kiro/specs/contextforge/design.md
+++ b/.kiro/specs/contextforge/design.md
@@ -47,7 +47,7 @@ graph LR
     end
     subgraph "Domain Layer"
         E["Entities (ContextItem, Chunk, CacheEntry, ProviderConfig, SessionConfig, LLMConfig)"]
-        P["Ports / Interfaces (ProviderInterface, CacheRepositoryInterface, LLMEngineInterface, SummarizeEngineInterface)"]
+        P["Ports / Interfaces (ProviderInterface, CacheRepositoryInterface, LLMEngineInterface, TextProcessingInterface)"]
         EX["Domain Exceptions"]
     end
     subgraph "Infrastructure Layer"
@@ -97,7 +97,7 @@ graph LR
 | **S** - Single Responsibility | Cada caso de uso tiene una única responsabilidad (leer, resumir, fragmentar). Cada controller maneja un único endpoint MCP. |
 | **O** - Open/Closed | `ProviderFactory` y `LLMFactory` permiten agregar implementaciones sin modificar código existente |
 | **L** - Liskov Substitution | `YouTrackProvider` y `JiraProvider` son intercambiables vía `ProviderInterface` |
-| **I** - Interface Segregation | Interfaces separadas para proveedor (`ProviderInterface`), caché (`CacheRepositoryInterface`), motor LLM (`LLMEngineInterface`) y summarization (`SummarizeEngineInterface`) |
+| **I** - Interface Segregation | Interfaces genéricas: proveedor (`ProviderInterface`), caché (`CacheRepositoryInterface`), motor LLM (`LLMEngineInterface`) y procesamiento de texto (`TextProcessingInterface`). Protocolos `LLM` y `Embeddings` permiten implementar con cualquier motor (Gemini, OpenAI, Grok, etc.) |
 | **D** - Dependency Inversion | Los casos de uso dependen de interfaces, no de implementaciones concretas |
 
 ---
@@ -524,8 +524,19 @@ class CacheEntry:
 
 ```python
 # src/domain/interfaces.py
+from __future__ import annotations
 from abc import ABC, abstractmethod
+from typing import Any, Protocol
 from .entities import ContextItem, ProviderConfig, CacheEntry, Chunk, LLMConfig
+
+# Protocolos genéricos para permitir implementaciones con cualquier LLM (Gemini, OpenAI, Grok, etc.)
+class LLM(Protocol):
+    def get_num_tokens(self, text: str) -> int: ...
+    def invoke(self, input: Any) -> Any: ...
+    def __or__(self, other: Any) -> Any: ...
+
+class Embeddings(Protocol):
+    def embed_query(self, text: str) -> list[float]: ...
 
 class ProviderInterface(ABC):
     @abstractmethod
@@ -538,7 +549,7 @@ class CacheRepositoryInterface(ABC):
     @abstractmethod
     def lookup(self, item_id: str, provider_name: str, content_hash: str, tool: str, **kwargs) -> CacheEntry | None:
         """Busca en caché por item_id + provider_name + content_hash + tool + params adicionales.
-        
+
         IMPORTANTE: El content_hash es requerido para buscar. Se calcula desde el raw_content
         del ContextItem después de obtenerlo del proveedor. Esto permite detectar si el contenido
         cambió (nuevo content_hash = cache miss).
@@ -552,16 +563,20 @@ class CacheRepositoryInterface(ABC):
     def invalidate(self, item_id: str, provider_name: str, tool: str) -> None: ...
 
 class LLMEngineInterface(ABC):
-    @property
-    @abstractmethod
-    def llm(self) -> ChatGoogleGenerativeAI: ...
+    """Interfaz genérica para motores LLM. Expone .llm y .embeddings."""
 
     @property
     @abstractmethod
-    def embeddings(self) -> GoogleGenerativeAIEmbeddings: ...
+    def llm(self) -> LLM: ...
+
+    @property
+    @abstractmethod
+    def embeddings(self) -> Embeddings: ...
 
 
-class SummarizeEngineInterface(ABC):
+class TextProcessingInterface(ABC):
+    """Interfaz genérica para procesamiento de texto con LLM."""
+
     @abstractmethod
     def summarize(self, content: str, max_tokens: int) -> str: ...
 
@@ -634,27 +649,24 @@ provider = factory.create()
 
 ## Infrastructure Layer: LLMFactory
 
-El `LLMFactory` es un factory simple que instancia el motor correcto según `engine_type` de `LLMConfig`. Crea internamente `GeminiLLMEngine` y `Summarized`, retornando este último que implementa `SummarizeEngineInterface`.
+El `LLMFactory` es un factory simple que instancia el motor correcto según `engine_type` de `LLMConfig`. Retorna `GeminiLLMEngine` que implementa `LLMEngineInterface`.
 
 ```python
 # src/infrastructure/llm/factory.py
 from src.domain.entities import LLMConfig
 from src.domain.exceptions import LLMEngineNotRegisteredError
-from src.domain.interfaces import SummarizeEngineInterface
+from src.domain.interfaces import LLMEngineInterface
 from src.infrastructure.llm.gemini import GeminiLLMEngine
-from src.infrastructure.llm.prompts import SUMMARIZE_PROMPT
-from src.infrastructure.llm.summarized import Summarized
 
 
 class LLMFactory:
     def __init__(self, config: LLMConfig) -> None:
         self.config = config
 
-    def create(self) -> SummarizeEngineInterface:
+    def create(self) -> LLMEngineInterface:
         engine_type = self.config.engine_type
         if engine_type == "gemini":
-            engine_llm = GeminiLLMEngine(self.config)
-            return Summarized(engine_llm, SUMMARIZE_PROMPT)
+            return GeminiLLMEngine(self.config)
         raise LLMEngineNotRegisteredError(
             f"Motor LLM '{engine_type}' no reconocido. Disponibles: gemini"
         )
@@ -666,7 +678,7 @@ class LLMFactory:
 # Uso simple - engine_type determina qué motor instanciar
 config = LLMConfig(engine_type="gemini", api_key="xxx")
 factory = LLMFactory(config)
-summarized = factory.create()  # Retorna Summarized (SummarizeEngineInterface)
+engine = factory.create()  # Retorna GeminiLLMEngine (LLMEngineInterface)
 ```
 
 ---
@@ -781,7 +793,7 @@ class ReadFullUseCase:
 ```python
 # src/application/services/read_summarize.py
 from datetime import datetime, timezone
-from src.domain.interfaces import CacheRepositoryInterface, ProviderInterface, SummarizeEngineInterface
+from src.domain.interfaces import CacheRepositoryInterface, ProviderInterface, TextProcessingInterface
 from src.domain.entities import CacheEntry
 from src.domain.exceptions import ValidationError
 from src.infrastructure.builders.cache_entry import CacheEntryBuilder
@@ -792,7 +804,7 @@ class ReadSummarizeUseCase:
         self,
         provider: ProviderInterface,
         cache: CacheRepositoryInterface,
-        summarized: SummarizeEngineInterface,
+        summarized: TextProcessingInterface,
     ) -> None:
         self._provider = provider
         self._cache = cache
@@ -1244,7 +1256,7 @@ class GeminiLLMEngine(LLMEngineInterface):
 
 ## Infrastructure Layer: Summarized
 
-Implementa `SummarizeEngineInterface`. Recibe un `LLMEngineInterface` y el template de prompt, construye la chain LCEL internamente.
+Implementa `TextProcessingInterface`. Recibe un `LLMEngineInterface` y el template de prompt, construye la chain LCEL internamente.
 
 ```python
 # src/infrastructure/llm/summarized.py
@@ -1252,10 +1264,10 @@ from langchain_core.output_parsers import StrOutputParser
 from langchain_core.prompts import ChatPromptTemplate
 
 from src.domain.exceptions import LLMError
-from src.domain.interfaces import LLMEngineInterface, SummarizeEngineInterface
+from src.domain.interfaces import LLMEngineInterface, TextProcessingInterface
 
 
-class Summarized(SummarizeEngineInterface):
+class Summarized(TextProcessingInterface):
     def __init__(
         self,
         engine_llm: LLMEngineInterface,

--- a/.kiro/specs/contextforge/tasks.md
+++ b/.kiro/specs/contextforge/tasks.md
@@ -196,21 +196,34 @@ Implementación incremental de ContextForge siguiendo Clean Architecture: primer
     > Centralizar el prompt en un archivo dedicado evita duplicación y facilita ajustarlo sin tocar la lógica del engine. Usar `ChatPromptTemplate.from_messages` con roles `system`/`human` es la práctica recomendada de LangChain.
     - Crear `src/infrastructure/llm/prompts.py`:
       - Importar `ChatPromptTemplate` de `langchain_core.prompts`
-      - Definir constante `SUMMARIZE_PROMPT = ChatPromptTemplate.from_messages([("system", "..."), ("human", "...")])` con variables `{max_tokens}` y `{content}`
-      - El mensaje `system` debe instruir al modelo a resumir en máximo `{max_tokens}` tokens
-      - El mensaje `human` debe contener el `{content}` a resumir
+      - Definir `SUMMARIZE_PROMPT` con el prompt técnico para IA:
+        ```
+        System: Eres un asistente técnico especializado en resumir contenido.
+        Reglas: máximo {max_tokens} tokens, información verificable, no inventar, priorizar problema/contexto/puntos clave
+        Human: Contenido a resumir: {content}
+        ```
     - _Ver `requirements.md`: Req. 8 — LLMFactory (§6)_
 
-  - [ ] 7.2 Implementar `GeminiLLMEngine`
-    > Implementación concreta del motor LLM usando Gemini. Construye la chain LCEL que conecta el prompt con el modelo y el parser de salida.
-    - Crear `src/infrastructure/llm/gemini.py` implementando `LLMEngineInterface`:
-      - Constructor recibe `config: LLMConfig` e inicializa:
-        - `self._llm = ChatGoogleGenerativeAI(model="gemini-2.0-flash", google_api_key=config.api_key)`
-        - `self._embeddings = GoogleGenerativeAIEmbeddings(model="models/text-embedding-004", google_api_key=config.api_key)`
-        - `self._chain = SUMMARIZE_PROMPT | self._llm | StrOutputParser()` (chain LCEL)
-      - `summarize(content, max_tokens)`: invoca `self._chain.invoke({"content": content, "max_tokens": max_tokens})`; capturar cualquier excepción y relanzar como `LLMError`
+  - [ ] 7.2 Refactorizar `GeminiLLMEngine`
+    > Implementación concreta del motor LLM usando Gemini. Expone `.llm` y `.embeddings` para que `Summarized` los use internamente.
+    - Refactorizar `src/infrastructure/llm/gemini.py` implementando `LLMEngineInterface`:
+      - Constructor recibe solo `config: LLMConfig`
+      - Inicializa `ChatGoogleGenerativeAI` y `GoogleGenerativeAIEmbeddings`
+      - `@property llm`: retorna `ChatGoogleGenerativeAI`
+      - `@property embeddings`: retorna `GoogleGenerativeAIEmbeddings`
+      - Modelo configurable via `config.model_version` (default: `gemini-2.5-flash-lite`)
+    - _Ver `requirements.md`: Req. 8 — LLMFactory (§5,6,7)_
+
+  - [ ] 7.3 Implementar `Summarized`
+    > Implementa `SummarizeEngineInterface`. Recibe un `LLMEngineInterface` y el template de prompt, construye la chain LCEL internamente.
+    - Crear `src/infrastructure/llm/summarized.py` implementando `SummarizeEngineInterface`:
+      - Constructor recibe `engine_llm: LLMEngineInterface` y `prompt_template: ChatPromptTemplate`
+      - Extrae `self._llm = engine_llm.llm` y `self._embeddings = engine_llm.embeddings`
+      - Construye chain LCEL: `prompt_template | self._llm | StrOutputParser()`
+      - `summarize(content, max_tokens)`: invoca la chain LCEL
       - `count_tokens(text)`: retorna `self._llm.get_num_tokens(text)`
       - `get_embeddings(text)`: retorna `self._embeddings.embed_query(text)`
+    - Actualizar `src/infrastructure/llm/factory.py` para crear `Summarized(engine_llm, SUMMARIZE_PROMPT)` y retornarlo
     - _Ver `requirements.md`: Req. 8 — LLMFactory (§5,6,7)_
 
 
@@ -260,14 +273,14 @@ Implementación incremental de ContextForge siguiendo Clean Architecture: primer
 
   - [ ] 9.3 Implementar `ReadSummarizeUseCase`
     > Devuelve un resumen del ítem generado por el LLM. El flujo híbrido garantiza datos siempre actualizados: primero va al proveedor, calcula content_hash, luego busca en caché. Si hay hit (contenido no cambió), retorna caché sin llamar LLM.
-    - Crear `src/application/use_cases/read_summarize.py`:
-      - Constructor recibe `provider`, `cache` y `llm: LLMEngineInterface`
+    - Crear `src/application/services/read_summarize.py`:
+      - Constructor recibe `provider`, `cache` y `summarized: SummarizeEngineInterface`
       - `execute(item_id, provider_name, max_tokens=500)`:
         1. Validar que `max_tokens` esté en el rango [1, 10000]; si no, lanzar `ValidationError` con mensaje descriptivo
         2. **PRIMERO:** Llamar `provider.get_item(item_id, provider._config)` para obtener `ContextItem` con content_hash
         3. Buscar en caché con `cache.lookup(item_id, provider_name, item.content_hash, "read_summarize", max_tokens=max_tokens)`
         4. Si hay hit: retornar la entrada cacheada
-        5. Si hay miss: llamar `llm.summarize(item.raw_content, max_tokens)` para generar el resumen
+        5. Si hay miss: llamar `summarized.summarize(item.raw_content, max_tokens)` para generar el resumen
         6. Construir `CacheEntry` con el resumen y `metadata={"max_tokens": max_tokens}`, guardar en caché y retornar
     - _Ver `requirements.md`: Req. 4 — read_summarize (§1,2,3,4,5,6,7)_
 
@@ -281,8 +294,9 @@ Implementación incremental de ContextForge siguiendo Clean Architecture: primer
 
   - [ ] 9.5 Implementar `ReadChunksUseCase`
     > Divide el contenido del ítem en fragmentos de máximo 500 tokens, respetando límites de oraciones. El flujo híbrido garantiza datos siempre actualizados: primero va al proveedor, luego busca en caché por content_hash. El cliente puede pedir todos los chunks o solo algunos por índice.
-    - Crear `src/application/use_cases/read_chunks.py`:
-      - Constructor recibe `provider`, `cache` y `llm`
+    > **Nota:** `ReadChunksUseCase` tiene la misma estructura que `ReadSummarizeUseCase` (`provider, cache, summarized`) pero con lógica distinta: usa `count_tokens()` directamente del engine.
+    - Crear `src/application/services/read_chunks.py`:
+      - Constructor recibe `provider`, `cache` y `summarized: SummarizeEngineInterface`
       - `execute(item_id, provider_name, chunk_indices=None)`:
         1. **PRIMERO:** Llamar `provider.get_item(item_id, provider._config)` para obtener `ContextItem` con content_hash
         2. Buscar en caché con `cache.lookup(item_id, provider_name, item.content_hash, "read_chunks")`

--- a/.kiro/specs/contextforge/tasks.md
+++ b/.kiro/specs/contextforge/tasks.md
@@ -215,8 +215,8 @@ Implementación incremental de ContextForge siguiendo Clean Architecture: primer
     - _Ver `requirements.md`: Req. 8 — LLMFactory (§5,6,7)_
 
   - [ ] 7.3 Implementar `Summarized`
-    > Implementa `SummarizeEngineInterface`. Recibe un `LLMEngineInterface` y el template de prompt, construye la chain LCEL internamente.
-    - Crear `src/infrastructure/llm/summarized.py` implementando `SummarizeEngineInterface`:
+    > Implementa `TextProcessingInterface`. Recibe un `LLMEngineInterface` y el template de prompt, construye la chain LCEL internamente.
+    - Crear `src/infrastructure/llm/summarized.py` implementando `TextProcessingInterface`:
       - Constructor recibe `engine_llm: LLMEngineInterface` y `prompt_template: ChatPromptTemplate`
       - Extrae `self._llm = engine_llm.llm` y `self._embeddings = engine_llm.embeddings`
       - Construye chain LCEL: `prompt_template | self._llm | StrOutputParser()`
@@ -274,7 +274,7 @@ Implementación incremental de ContextForge siguiendo Clean Architecture: primer
   - [ ] 9.3 Implementar `ReadSummarizeUseCase`
     > Devuelve un resumen del ítem generado por el LLM. El flujo híbrido garantiza datos siempre actualizados: primero va al proveedor, calcula content_hash, luego busca en caché. Si hay hit (contenido no cambió), retorna caché sin llamar LLM.
     - Crear `src/application/services/read_summarize.py`:
-      - Constructor recibe `provider`, `cache` y `summarized: SummarizeEngineInterface`
+      - Constructor recibe `provider`, `cache` y `summarized: TextProcessingInterface`
       - `execute(item_id, provider_name, max_tokens=500)`:
         1. Validar que `max_tokens` esté en el rango [1, 10000]; si no, lanzar `ValidationError` con mensaje descriptivo
         2. **PRIMERO:** Llamar `provider.get_item(item_id, provider._config)` para obtener `ContextItem` con content_hash
@@ -296,7 +296,7 @@ Implementación incremental de ContextForge siguiendo Clean Architecture: primer
     > Divide el contenido del ítem en fragmentos de máximo 500 tokens, respetando límites de oraciones. El flujo híbrido garantiza datos siempre actualizados: primero va al proveedor, luego busca en caché por content_hash. El cliente puede pedir todos los chunks o solo algunos por índice.
     > **Nota:** `ReadChunksUseCase` tiene la misma estructura que `ReadSummarizeUseCase` (`provider, cache, summarized`) pero con lógica distinta: usa `count_tokens()` directamente del engine.
     - Crear `src/application/services/read_chunks.py`:
-      - Constructor recibe `provider`, `cache` y `summarized: SummarizeEngineInterface`
+      - Constructor recibe `provider`, `cache` y `summarized: TextProcessingInterface`
       - `execute(item_id, provider_name, chunk_indices=None)`:
         1. **PRIMERO:** Llamar `provider.get_item(item_id, provider._config)` para obtener `ContextItem` con content_hash
         2. Buscar en caché con `cache.lookup(item_id, provider_name, item.content_hash, "read_chunks")`

--- a/src/application/services/__init__.py
+++ b/src/application/services/__init__.py
@@ -1,0 +1,3 @@
+from src.application.services.read_summarize import ReadSummarizeUseCase
+
+__all__ = ["ReadSummarizeUseCase"]

--- a/src/application/services/read_summarize.py
+++ b/src/application/services/read_summarize.py
@@ -5,7 +5,7 @@ from src.domain.exceptions import ValidationError
 from src.domain.interfaces import (
     CacheRepositoryInterface,
     ProviderInterface,
-    SummarizeEngineInterface,
+    TextProcessingInterface,
 )
 from src.infrastructure.builders.cache_entry import CacheEntryBuilder
 
@@ -15,7 +15,7 @@ class ReadSummarizeUseCase:
         self,
         provider: ProviderInterface,
         cache: CacheRepositoryInterface,
-        summarized: SummarizeEngineInterface,
+        summarized: TextProcessingInterface,
     ) -> None:
         self._provider = provider
         self._cache = cache

--- a/src/application/services/read_summarize.py
+++ b/src/application/services/read_summarize.py
@@ -1,0 +1,52 @@
+from datetime import datetime, timezone
+
+from src.domain.entities import CacheEntry
+from src.domain.exceptions import ValidationError
+from src.domain.interfaces import (
+    CacheRepositoryInterface,
+    ProviderInterface,
+    SummarizeEngineInterface,
+)
+from src.infrastructure.builders.cache_entry import CacheEntryBuilder
+
+
+class ReadSummarizeUseCase:
+    def __init__(
+        self,
+        provider: ProviderInterface,
+        cache: CacheRepositoryInterface,
+        summarized: SummarizeEngineInterface,
+    ) -> None:
+        self._provider = provider
+        self._cache = cache
+        self._summarized = summarized
+
+    def execute(
+        self,
+        item_id: str,
+        provider_name: str,
+        max_tokens: int = 500,
+    ) -> CacheEntry:
+        if not (1 <= max_tokens <= 10000):
+            raise ValidationError("max_tokens debe estar entre 1 y 10000")
+
+        item = self._provider.get_item(item_id, self._provider._config)  # type: ignore[attr-defined]
+
+        cached = self._cache.lookup(
+            item_id, provider_name, item.content_hash, "read_summarize", max_tokens=max_tokens
+        )
+        if cached:
+            return cached
+
+        summary = self._summarized.summarize(item.raw_content, max_tokens)
+
+        entry = (
+            CacheEntryBuilder()
+            .for_item(item)
+            .with_tool("read_summarize")
+            .with_content(summary)
+            .with_metadata(max_tokens=max_tokens, timestamp=datetime.now(timezone.utc).isoformat())
+            .build()
+        )
+        self._cache.store(entry)
+        return entry

--- a/src/domain/entities.py
+++ b/src/domain/entities.py
@@ -18,6 +18,7 @@ class SessionConfig:
 class LLMConfig:
     engine_type: str
     api_key: str
+    model_version: str = "gemini-2.5-flash-lite"
 
 
 @dataclass

--- a/src/domain/interfaces.py
+++ b/src/domain/interfaces.py
@@ -1,6 +1,12 @@
+from __future__ import annotations
+
 from abc import ABC, abstractmethod
+from typing import TYPE_CHECKING
 
 from .entities import CacheEntry, ContextItem, ProviderConfig
+
+if TYPE_CHECKING:
+    from langchain_google_genai import ChatGoogleGenerativeAI, GoogleGenerativeAIEmbeddings
 
 
 class ProviderInterface(ABC):
@@ -38,6 +44,16 @@ class CacheRepositoryInterface(ABC):
 
 
 class LLMEngineInterface(ABC):
+    @property
+    @abstractmethod
+    def llm(self) -> "ChatGoogleGenerativeAI": ...
+
+    @property
+    @abstractmethod
+    def embeddings(self) -> "GoogleGenerativeAIEmbeddings": ...
+
+
+class SummarizeEngineInterface(ABC):
     @abstractmethod
     def summarize(self, content: str, max_tokens: int) -> str: ...
 

--- a/src/domain/interfaces.py
+++ b/src/domain/interfaces.py
@@ -1,12 +1,40 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from typing import TYPE_CHECKING
+from typing import Any, Protocol
 
 from .entities import CacheEntry, ContextItem, ProviderConfig
 
-if TYPE_CHECKING:
-    from langchain_google_genai import ChatGoogleGenerativeAI, GoogleGenerativeAIEmbeddings
+
+class LLM(Protocol):
+    def get_num_tokens(self, text: str) -> int: ...
+    def invoke(self, input: Any) -> Any: ...
+    def __or__(self, other: Any) -> Any: ...
+
+
+class Embeddings(Protocol):
+    def embed_query(self, text: str) -> list[float]: ...
+
+
+class LLMEngineInterface(ABC):
+    @property
+    @abstractmethod
+    def llm(self) -> LLM: ...
+
+    @property
+    @abstractmethod
+    def embeddings(self) -> Embeddings: ...
+
+
+class TextProcessingInterface(ABC):
+    @abstractmethod
+    def summarize(self, content: str, max_tokens: int) -> str: ...
+
+    @abstractmethod
+    def count_tokens(self, text: str) -> int: ...
+
+    @abstractmethod
+    def get_embeddings(self, text: str) -> list[float]: ...
 
 
 class ProviderInterface(ABC):
@@ -41,24 +69,3 @@ class CacheRepositoryInterface(ABC):
 
     @abstractmethod
     def invalidate(self, item_id: str, provider_name: str, tool: str) -> None: ...
-
-
-class LLMEngineInterface(ABC):
-    @property
-    @abstractmethod
-    def llm(self) -> "ChatGoogleGenerativeAI": ...
-
-    @property
-    @abstractmethod
-    def embeddings(self) -> "GoogleGenerativeAIEmbeddings": ...
-
-
-class SummarizeEngineInterface(ABC):
-    @abstractmethod
-    def summarize(self, content: str, max_tokens: int) -> str: ...
-
-    @abstractmethod
-    def count_tokens(self, text: str) -> int: ...
-
-    @abstractmethod
-    def get_embeddings(self, text: str) -> list[float]: ...

--- a/src/infrastructure/llm/factory.py
+++ b/src/infrastructure/llm/factory.py
@@ -1,20 +1,17 @@
 from src.domain.entities import LLMConfig
 from src.domain.exceptions import LLMEngineNotRegisteredError
-from src.domain.interfaces import SummarizeEngineInterface
+from src.domain.interfaces import LLMEngineInterface
 from src.infrastructure.llm.gemini import GeminiLLMEngine
-from src.infrastructure.llm.prompts import SUMMARIZE_PROMPT
-from src.infrastructure.llm.summarized import Summarized
 
 
 class LLMFactory:
     def __init__(self, config: LLMConfig) -> None:
         self.config = config
 
-    def create(self) -> SummarizeEngineInterface:
+    def create(self) -> LLMEngineInterface:
         engine_type = self.config.engine_type
         if engine_type == "gemini":
-            engine_llm = GeminiLLMEngine(self.config)
-            return Summarized(engine_llm, SUMMARIZE_PROMPT)
+            return GeminiLLMEngine(self.config)
         raise LLMEngineNotRegisteredError(
             f"Motor LLM '{engine_type}' no reconocido. Disponibles: gemini"
         )

--- a/src/infrastructure/llm/factory.py
+++ b/src/infrastructure/llm/factory.py
@@ -1,17 +1,20 @@
 from src.domain.entities import LLMConfig
 from src.domain.exceptions import LLMEngineNotRegisteredError
-from src.domain.interfaces import LLMEngineInterface
+from src.domain.interfaces import SummarizeEngineInterface
 from src.infrastructure.llm.gemini import GeminiLLMEngine
+from src.infrastructure.llm.prompts import SUMMARIZE_PROMPT
+from src.infrastructure.llm.summarized import Summarized
 
 
 class LLMFactory:
     def __init__(self, config: LLMConfig) -> None:
         self.config = config
 
-    def create(self) -> LLMEngineInterface:
+    def create(self) -> SummarizeEngineInterface:
         engine_type = self.config.engine_type
         if engine_type == "gemini":
-            return GeminiLLMEngine(self.config)
+            engine_llm = GeminiLLMEngine(self.config)
+            return Summarized(engine_llm, SUMMARIZE_PROMPT)
         raise LLMEngineNotRegisteredError(
             f"Motor LLM '{engine_type}' no reconocido. Disponibles: gemini"
         )

--- a/src/infrastructure/llm/gemini.py
+++ b/src/infrastructure/llm/gemini.py
@@ -1,7 +1,7 @@
 from langchain_google_genai import ChatGoogleGenerativeAI, GoogleGenerativeAIEmbeddings
 
 from src.domain.entities import LLMConfig
-from src.domain.interfaces import LLMEngineInterface
+from src.domain.interfaces import LLM, Embeddings, LLMEngineInterface
 
 
 class GeminiLLMEngine(LLMEngineInterface):
@@ -17,9 +17,9 @@ class GeminiLLMEngine(LLMEngineInterface):
         )  # type: ignore[call-arg]
 
     @property
-    def llm(self) -> ChatGoogleGenerativeAI:
+    def llm(self) -> LLM:
         return self._llm
 
     @property
-    def embeddings(self) -> GoogleGenerativeAIEmbeddings:
+    def embeddings(self) -> Embeddings:
         return self._embeddings

--- a/src/infrastructure/llm/gemini.py
+++ b/src/infrastructure/llm/gemini.py
@@ -1,3 +1,5 @@
+from langchain_google_genai import ChatGoogleGenerativeAI, GoogleGenerativeAIEmbeddings
+
 from src.domain.entities import LLMConfig
 from src.domain.interfaces import LLMEngineInterface
 
@@ -5,12 +7,19 @@ from src.domain.interfaces import LLMEngineInterface
 class GeminiLLMEngine(LLMEngineInterface):
     def __init__(self, config: LLMConfig) -> None:
         self._config = config
+        self._llm = ChatGoogleGenerativeAI(
+            model=config.model_version,
+            google_api_key=config.api_key,
+        )
+        self._embeddings = GoogleGenerativeAIEmbeddings(
+            model="models/text-embedding-004",
+            google_api_key=config.api_key,
+        )  # type: ignore[call-arg]
 
-    def summarize(self, content: str, max_tokens: int) -> str:
-        raise NotImplementedError("GeminiLLMEngine no implementado aún")
+    @property
+    def llm(self) -> ChatGoogleGenerativeAI:
+        return self._llm
 
-    def count_tokens(self, text: str) -> int:
-        raise NotImplementedError("GeminiLLMEngine no implementado aún")
-
-    def get_embeddings(self, text: str) -> list[float]:
-        raise NotImplementedError("GeminiLLMEngine no implementado aún")
+    @property
+    def embeddings(self) -> GoogleGenerativeAIEmbeddings:
+        return self._embeddings

--- a/src/infrastructure/llm/prompts.py
+++ b/src/infrastructure/llm/prompts.py
@@ -1,0 +1,19 @@
+from langchain_core.prompts import ChatPromptTemplate
+
+SUMMARIZE_PROMPT = ChatPromptTemplate.from_messages([
+    (
+        "system",
+        """Eres un asistente técnico especializado en resumir contenido de manera concisa y precisa.
+
+Reglas:
+- Máximo {max_tokens} tokens
+- Incluir solo información relevante y verificable
+- Mantener claridad y estructura
+- No inventar ni añadir información no presente en el contenido original
+- Priorizar: problema, contexto, estado actual, puntos clave""",
+    ),
+    (
+        "human",
+        "Contenido a resumir:\n\n{content}",
+    ),
+])

--- a/src/infrastructure/llm/summarized.py
+++ b/src/infrastructure/llm/summarized.py
@@ -2,10 +2,10 @@ from langchain_core.output_parsers import StrOutputParser
 from langchain_core.prompts import ChatPromptTemplate
 
 from src.domain.exceptions import LLMError
-from src.domain.interfaces import LLMEngineInterface, SummarizeEngineInterface
+from src.domain.interfaces import LLMEngineInterface, TextProcessingInterface
 
 
-class Summarized(SummarizeEngineInterface):
+class Summarized(TextProcessingInterface):
     def __init__(
         self,
         engine_llm: LLMEngineInterface,
@@ -13,16 +13,18 @@ class Summarized(SummarizeEngineInterface):
     ) -> None:
         self._llm = engine_llm.llm
         self._embeddings = engine_llm.embeddings
-        self._chain = prompt_template | self._llm | StrOutputParser()
+        self._prompt_template = prompt_template
 
     def summarize(self, content: str, max_tokens: int) -> str:
         try:
-            return self._chain.invoke(
+            formatted_prompt = self._prompt_template.invoke(
                 {
                     "content": content,
                     "max_tokens": max_tokens,
                 }
             )
+            llm_response = self._llm.invoke(formatted_prompt)
+            return StrOutputParser().invoke(llm_response)
         except Exception as e:
             raise LLMError(f"Error al generar resumen: {e}") from e
 

--- a/src/infrastructure/llm/summarized.py
+++ b/src/infrastructure/llm/summarized.py
@@ -1,0 +1,33 @@
+from langchain_core.output_parsers import StrOutputParser
+from langchain_core.prompts import ChatPromptTemplate
+
+from src.domain.exceptions import LLMError
+from src.domain.interfaces import LLMEngineInterface, SummarizeEngineInterface
+
+
+class Summarized(SummarizeEngineInterface):
+    def __init__(
+        self,
+        engine_llm: LLMEngineInterface,
+        prompt_template: ChatPromptTemplate,
+    ) -> None:
+        self._llm = engine_llm.llm
+        self._embeddings = engine_llm.embeddings
+        self._chain = prompt_template | self._llm | StrOutputParser()
+
+    def summarize(self, content: str, max_tokens: int) -> str:
+        try:
+            return self._chain.invoke(
+                {
+                    "content": content,
+                    "max_tokens": max_tokens,
+                }
+            )
+        except Exception as e:
+            raise LLMError(f"Error al generar resumen: {e}") from e
+
+    def count_tokens(self, text: str) -> int:
+        return self._llm.get_num_tokens(text)
+
+    def get_embeddings(self, text: str) -> list[float]:
+        return self._embeddings.embed_query(text)

--- a/tests/property/test_llm_engine.py
+++ b/tests/property/test_llm_engine.py
@@ -1,0 +1,34 @@
+from src.domain.entities import LLMConfig
+from src.domain.exceptions import LLMEngineNotRegisteredError
+from src.infrastructure.llm.factory import LLMFactory
+from src.infrastructure.llm.gemini import GeminiLLMEngine
+from src.infrastructure.llm.prompts import SUMMARIZE_PROMPT
+from src.infrastructure.llm.summarized import Summarized
+
+
+def test_llm_factory_creates_gemini():
+    """Propiedad 18: LLMFactory crea GeminiLLMEngine para engine_type='gemini'"""
+    config = LLMConfig(engine_type="gemini", api_key="test")
+    factory = LLMFactory(config)
+    engine = factory.create()
+    assert isinstance(engine, GeminiLLMEngine)
+
+
+def test_llm_factory_creates_summarized():
+    """Propiedad 18: Summarized recibe GeminiLLMEngine y template para summarization"""
+    config = LLMConfig(engine_type="gemini", api_key="test")
+    factory = LLMFactory(config)
+    engine = factory.create()
+    summarized = Summarized(engine, SUMMARIZE_PROMPT)
+    assert isinstance(summarized, Summarized)
+
+
+def test_llm_factory_unknown_engine():
+    """Propiedad 18: Engine desconocido lanza LLMEngineNotRegisteredError"""
+    config = LLMConfig(engine_type="unknown", api_key="test")
+    factory = LLMFactory(config)
+    try:
+        factory.create()
+        assert False, "Should have raised LLMEngineNotRegisteredError"
+    except LLMEngineNotRegisteredError as e:
+        assert "unknown" in str(e)

--- a/tests/property/test_properties_providers.py
+++ b/tests/property/test_properties_providers.py
@@ -5,7 +5,7 @@ from src.domain.entities import LLMConfig, ProviderConfig
 from src.domain.exceptions import LLMEngineNotRegisteredError, ProviderNotRegisteredError
 from src.infrastructure.builders.context_item import ContextItemBuilder
 from src.infrastructure.llm.factory import LLMFactory
-from src.infrastructure.llm.gemini import GeminiLLMEngine
+from src.infrastructure.llm.summarized import Summarized
 from src.infrastructure.providers.factory import ProviderFactory
 from src.infrastructure.providers.task.youtrack import YouTrackProvider
 
@@ -101,11 +101,11 @@ def test_provider_factory_unknown_code():
 
 
 def test_llm_factory_creates_gemini():
-    """Propiedad 18: LLMFactory crea GeminiLLMEngine para engine_type='gemini'"""
+    """Propiedad 18: LLMFactory crea Summarized para engine_type='gemini'"""
     config = LLMConfig(engine_type="gemini", api_key="test")
     factory = LLMFactory(config)
     engine = factory.create()
-    assert isinstance(engine, GeminiLLMEngine)
+    assert isinstance(engine, Summarized)
 
 
 def test_llm_factory_unknown_engine():

--- a/tests/property/test_properties_providers.py
+++ b/tests/property/test_properties_providers.py
@@ -1,11 +1,9 @@
 from hypothesis import given, settings
 from hypothesis import strategies as st
 
-from src.domain.entities import LLMConfig, ProviderConfig
-from src.domain.exceptions import LLMEngineNotRegisteredError, ProviderNotRegisteredError
+from src.domain.entities import ProviderConfig
+from src.domain.exceptions import ProviderNotRegisteredError
 from src.infrastructure.builders.context_item import ContextItemBuilder
-from src.infrastructure.llm.factory import LLMFactory
-from src.infrastructure.llm.summarized import Summarized
 from src.infrastructure.providers.factory import ProviderFactory
 from src.infrastructure.providers.task.youtrack import YouTrackProvider
 
@@ -75,9 +73,6 @@ def test_context_item_builder_different_content_different_hash(
         assert builder.content_hash != builder_modified.content_hash
 
 
-# Feature: contextforge, Propiedad 16: ProviderFactory crea segun config.code
-
-
 def test_provider_factory_creates_youtrack():
     """Propiedad 16: ProviderFactory crea YouTrackProvider para code='youtrack'"""
     config = ProviderConfig(code="youtrack", token="test")
@@ -94,26 +89,4 @@ def test_provider_factory_unknown_code():
         factory.create()
         assert False, "Should have raised ProviderNotRegisteredError"
     except ProviderNotRegisteredError as e:
-        assert "unknown" in str(e)
-
-
-# Feature: contextforge, Propiedad 18: LLMFactory crea segun LLMConfig.engine_type
-
-
-def test_llm_factory_creates_gemini():
-    """Propiedad 18: LLMFactory crea Summarized para engine_type='gemini'"""
-    config = LLMConfig(engine_type="gemini", api_key="test")
-    factory = LLMFactory(config)
-    engine = factory.create()
-    assert isinstance(engine, Summarized)
-
-
-def test_llm_factory_unknown_engine():
-    """Propiedad 18: Engine desconocido lanza LLMEngineNotRegisteredError"""
-    config = LLMConfig(engine_type="unknown", api_key="test")
-    factory = LLMFactory(config)
-    try:
-        factory.create()
-        assert False, "Should have raised LLMEngineNotRegisteredError"
-    except LLMEngineNotRegisteredError as e:
         assert "unknown" in str(e)


### PR DESCRIPTION
## Summary
- Break down LCEL chain into explicit steps for readability
- Rename `SummarizeEngineInterface` to `TextProcessingInterface`
- Separate LLM tests into `test_llm_engine.py`

## Changes
- `src/infrastructure/llm/summarized.py`: Refactored to use explicit chain steps
- `tests/property/test_llm_engine.py`: New file with LLM tests
- `tests/property/test_properties_providers.py`: Removed LLM tests