### PR TITLE
feat(MCF-8): Implement ChromaCacheRepository

### DIFF
--- a/src/infrastructure/cache/chroma.py
+++ b/src/infrastructure/cache/chroma.py
@@ -1,0 +1,70 @@
+import chromadb
+
+from ...domain.entities import CacheEntry
+from ...domain.interfaces import CacheRepositoryInterface
+
+
+class ChromaCacheRepository(CacheRepositoryInterface):
+    def __init__(self, host: str, port: int) -> None:
+        self._client = chromadb.HttpClient(host=host, port=port)
+        self._collection = self._client.get_or_create_collection("contextforge_cache")
+
+    def lookup(
+        self,
+        item_id: str,
+        provider_name: str,
+        content_hash: str,
+        tool: str,
+        **kwargs,
+    ) -> CacheEntry | None:
+        where = {
+            "item_id": item_id,
+            "provider_name": provider_name,
+            "content_hash": content_hash,
+            "tool": tool,
+        }
+        if "max_tokens" in kwargs:
+            where["max_tokens"] = kwargs["max_tokens"]
+        results = self._collection.get(where=where, include=["documents", "metadatas"])  # type: ignore[arg-type]
+        if not results["documents"]:
+            return None
+        metadata = results["metadatas"][0] if results["metadatas"] else {}
+        return CacheEntry(
+            item_id=item_id,
+            provider_name=provider_name,
+            content_hash=content_hash,
+            tool=tool,
+            content=results["documents"][0],
+            metadata=metadata,  # type: ignore[arg-type]
+            from_cache=True,
+        )
+
+    def store(self, entry: CacheEntry) -> None:
+        doc_id = _build_doc_id(entry)
+        self._collection.upsert(
+            ids=[doc_id],
+            documents=[entry.content],
+            metadatas=[
+                {
+                    **entry.metadata,
+                    "item_id": entry.item_id,
+                    "provider_name": entry.provider_name,
+                    "content_hash": entry.content_hash,
+                    "tool": entry.tool,
+                }
+            ],
+        )
+
+    def invalidate(self, item_id: str, provider_name: str, tool: str) -> None:
+        self._collection.delete(
+            where={"item_id": item_id, "provider_name": provider_name, "tool": tool}  # type: ignore[arg-type]
+        )
+
+
+def _build_doc_id(entry: CacheEntry) -> str:
+    base = f"{entry.item_id}::{entry.provider_name}::{entry.content_hash}::{entry.tool}"
+    if entry.tool == "read_summarize" and "max_tokens" in entry.metadata:
+        return f"{base}::{entry.metadata['max_tokens']}"
+    if entry.tool == "read_chunks" and "chunk_index" in entry.metadata:
+        return f"{base}::{entry.metadata['chunk_index']}"
+    return base

--- a/tests/unit/test_chroma_cache.py
+++ b/tests/unit/test_chroma_cache.py
@@ -1,0 +1,67 @@
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from src.domain.entities import CacheEntry
+from src.infrastructure.cache.chroma import ChromaCacheRepository
+
+
+@pytest.fixture
+def mock_collection():
+    return MagicMock()
+
+
+@pytest.fixture
+def mock_client(mock_collection):
+    with patch("chromadb.HttpClient") as mock:
+        mock.return_value.get_or_create_collection.return_value = mock_collection
+        yield mock
+
+
+@pytest.fixture
+def cache(mock_client, mock_collection):
+    return ChromaCacheRepository(host="localhost", port=8000)
+
+
+def test_lookup_cache_hit(cache, mock_collection):
+    """Cuando ChromaDB retorna un documento, lookup() debe retornar CacheEntry con from_cache=True."""
+    mock_collection.get.return_value = {
+        "documents": ["contenido cacheado"],
+        "metadatas": [{"timestamp": "2026-01-01"}],
+    }
+    entry = cache.lookup("1", "youtrack", "abc123", "read_full")
+    assert entry is not None
+    assert entry.from_cache is True
+    assert entry.content == "contenido cacheado"
+
+
+def test_lookup_cache_miss(cache, mock_collection):
+    """Cuando ChromaDB retorna lista vacía, lookup() debe retornar None (cache miss)."""
+    mock_collection.get.return_value = {"documents": [], "metadatas": []}
+    entry = cache.lookup("1", "youtrack", "abc123", "read_full")
+    assert entry is None
+
+
+def test_store_calls_upsert(cache, mock_collection):
+    """store() debe llamar a ChromaDB.upsert() con el documento y metadatos correctos."""
+    entry = CacheEntry(
+        item_id="1",
+        provider_name="youtrack",
+        content_hash="abc",
+        tool="read_full",
+        content="test",
+        metadata={"a": 1},
+        from_cache=False,
+    )
+    cache.store(entry)
+    mock_collection.upsert.assert_called_once()
+    call_args = mock_collection.upsert.call_args
+    assert call_args.kwargs["documents"] == ["test"]
+
+
+def test_invalidate_calls_delete(cache, mock_collection):
+    """invalidate() debe llamar a ChromaDB.delete() con los filtros item_id, provider_name y tool."""
+    cache.invalidate("1", "youtrack", "read_full")
+    mock_collection.delete.assert_called_once_with(
+        where={"item_id": "1", "provider_name": "youtrack", "tool": "read_full"}
+    )


### PR DESCRIPTION
## Summary
Implement ChromaCacheRepository using ChromaDB for caching.

## Changes
- `src/infrastructure/cache/chroma.py`: ChromaCacheRepository with `lookup()`, `store()`, `invalidate()`
- `tests/unit/test_chroma_cache.py`: 4 unit tests with mocks

## What it does
- **lookup()**: Searches ChromaDB by `item_id + provider_name + content_hash + tool`
- **store()**: Saves entries with unique document ID
- **invalidate()**: Deletes entries by filters

## Tests
- `test_lookup_cache_hit` ✅
- `test_lookup_cache_miss` ✅
- `test_store_calls_upsert` ✅
- `test_invalidate_calls_delete` ✅