### PR TITLE
MCF-13: Implementar schemas Pydantic y SessionManager

### DIFF
--- a/.kiro/specs/contextforge/design.md
+++ b/.kiro/specs/contextforge/design.md
@@ -461,19 +461,74 @@ class ToolCallRequest(BaseModel):
 # app/schemas/mcp_response.py
 from pydantic import BaseModel
 
+class ItemResponse(BaseModel):
+    index: int
+    content: str
+
 class ToolCallResponse(BaseModel):
-    content: str
-    from_cache: bool
+    items: list[ItemResponse]
+```
 
-class ChunkItem(BaseModel):
-    chunk_index: int
-    total_chunks: int
-    content: str
-    token_count: int
+---
 
-class ChunksResponse(BaseModel):
-    chunks: list[ChunkItem]
-    from_cache: bool
+## Ejemplos de Comunicación JSON (Protocolo MCP)
+
+Para facilitar la comprensión del flujo de datos entre el Agente de IA y ContextForge, a continuación se presentan los objetos JSON reales que se intercambian:
+
+### 1. Inicialización (`initialize`)
+Este mensaje es enviado por el cliente para configurar la sesión y los proveedores disponibles.
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "method": "initialize",
+  "params": {
+    "protocolVersion": "2025-03-26",
+    "clientInfo": {
+      "config": {
+        "providers": {
+          "youtrack": {
+            "token": "mi-token-secreto-123",
+            "base_url": "https://mi-empresa.youtrack.cloud"
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+### 2. Llamada a Herramienta (`tools/call`)
+Este mensaje solicita la ejecución de una herramienta específica (ej. `read_full`).
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 2,
+  "method": "tools/call",
+  "params": {
+    "name": "read_full",
+    "arguments": {
+      "item_id": "TICKET-101",
+      "provider_name": "youtrack"
+    }
+  }
+}
+```
+
+### 3. Respuesta del Servidor (`ToolCallResponse`)
+Formato de respuesta que el servidor devuelve al agente para que este lo procese.
+
+```json
+{
+  "items": [
+    {
+      "index": 1,
+      "content": "Contenido del ticket recuperado y procesado..."
+    }
+  ]
+}
 ```
 
 ---

--- a/app/schemas/__init__.py
+++ b/app/schemas/__init__.py
@@ -1,0 +1,22 @@
+from .errors import ErrorResponse
+from .mcp_request import (
+    ClientInfoSchema,
+    InitializeParams,
+    ProviderConfigSchema,
+    SessionConfigSchema,
+    ToolCallParams,
+    ToolCallRequest,
+)
+from .mcp_response import ItemResponse, ToolCallResponse
+
+__all__ = [
+    "ProviderConfigSchema",
+    "SessionConfigSchema",
+    "ClientInfoSchema",
+    "InitializeParams",
+    "ToolCallParams",
+    "ToolCallRequest",
+    "ItemResponse",
+    "ToolCallResponse",
+    "ErrorResponse",
+]

--- a/app/schemas/errors.py
+++ b/app/schemas/errors.py
@@ -1,0 +1,7 @@
+from pydantic import BaseModel
+
+
+class ErrorResponse(BaseModel):
+    message: str
+
+    model_config = {"json_schema_extra": {"example": {"message": "Descripción del error"}}}

--- a/app/schemas/mcp_request.py
+++ b/app/schemas/mcp_request.py
@@ -1,0 +1,33 @@
+from typing import Any
+
+from pydantic import BaseModel
+
+
+class ProviderConfigSchema(BaseModel):
+    token: str
+    base_url: str | None = None
+
+
+class SessionConfigSchema(BaseModel):
+    providers: dict[str, ProviderConfigSchema]
+
+
+class ClientInfoSchema(BaseModel):
+    config: SessionConfigSchema | None = None
+
+
+class InitializeParams(BaseModel):
+    clientInfo: ClientInfoSchema | None = None
+    protocolVersion: str = "2025-03-26"
+
+
+class ToolCallParams(BaseModel):
+    name: str
+    arguments: dict[str, Any] = {}
+
+
+class ToolCallRequest(BaseModel):
+    jsonrpc: str = "2.0"
+    id: str | int | None = None
+    method: str
+    params: dict[str, Any] = {}

--- a/app/schemas/mcp_response.py
+++ b/app/schemas/mcp_response.py
@@ -1,0 +1,10 @@
+from pydantic import BaseModel
+
+
+class ItemResponse(BaseModel):
+    index: int
+    content: str
+
+
+class ToolCallResponse(BaseModel):
+    items: list[ItemResponse]

--- a/app/session.py
+++ b/app/session.py
@@ -1,0 +1,25 @@
+from src.domain.entities import SessionConfig
+from src.domain.exceptions import SessionConfigError
+
+
+class SessionManager:
+    _sessions: dict[str, SessionConfig] = {}
+
+    def store(self, session_id: str, config: SessionConfig) -> None:
+        self._validate(config)
+        self._sessions[session_id] = config
+
+    def get(self, session_id: str) -> SessionConfig:
+        if session_id not in self._sessions:
+            raise SessionConfigError("Sesión no encontrada. Llama a initialize primero.")
+        return self._sessions[session_id]
+
+    def delete(self, session_id: str) -> None:
+        self._sessions.pop(session_id, None)
+
+    def _validate(self, config: SessionConfig) -> None:
+        if not config.providers:
+            raise SessionConfigError("La sesión debe tener al menos un proveedor")
+        for name, provider_config in config.providers.items():
+            if not provider_config.token or not provider_config.token.strip():
+                raise SessionConfigError(f"El token del proveedor '{name}' no puede estar vacío")

--- a/tests/property/test_properties_validation.py
+++ b/tests/property/test_properties_validation.py
@@ -1,0 +1,63 @@
+# Feature: contextforge, Propiedad 1: Validación de campos faltantes en ProviderConfig
+# Feature: contextforge, Propiedad 19: Validación de providers vacío en SessionConfig
+
+from hypothesis import given, settings
+from hypothesis import strategies as st
+
+from app.session import SessionManager
+from src.domain.entities import ProviderConfig, SessionConfig
+from src.domain.exceptions import SessionConfigError
+
+
+class TestSessionManagerValidation:
+    @given(
+        token=st.one_of(st.just(""), st.just("   "), st.just("\t")),
+        base_url=st.one_of(st.none(), st.text(min_size=0, max_size=200)),
+    )
+    @settings(max_examples=100)
+    def test_empty_token_raises_error(self, token: str, base_url: str | None) -> None:
+        config = SessionConfig(
+            providers={"test": ProviderConfig(code="youtrack", token=token, base_url=base_url)}
+        )
+        manager = SessionManager()
+        try:
+            manager.store("session-1", config)
+            assert False, "Expected SessionConfigError"
+        except SessionConfigError as e:
+            assert "token" in str(e).lower()
+
+    def test_empty_providers_raises_error(self) -> None:
+        config = SessionConfig(providers={})
+        manager = SessionManager()
+        try:
+            manager.store("session-1", config)
+            assert False, "Expected SessionConfigError"
+        except SessionConfigError as e:
+            assert "proveedor" in str(e).lower()
+
+    @given(
+        token=st.text(min_size=1, max_size=100),
+        base_url=st.one_of(st.none(), st.text(min_size=0, max_size=200)),
+    )
+    @settings(max_examples=100)
+    def test_valid_config_stored_successfully(self, token: str, base_url: str | None) -> None:
+        config = SessionConfig(
+            providers={"youtrack": ProviderConfig(code="youtrack", token=token, base_url=base_url)}
+        )
+        manager = SessionManager()
+        manager.store("session-1", config)
+        retrieved = manager.get("session-1")
+        assert retrieved.providers["youtrack"].token == token
+
+    def test_get_nonexistent_session_raises_error(self) -> None:
+        manager = SessionManager()
+        try:
+            manager.get("nonexistent")
+            assert False, "Expected SessionConfigError"
+        except SessionConfigError as e:
+            assert "no encontrada" in str(e).lower()
+
+    def test_delete_nonexistent_session_is_silent(self) -> None:
+        manager = SessionManager()
+        manager.delete("nonexistent")
+        assert "nonexistent" not in manager._sessions


### PR DESCRIPTION
## Summary
- Implementar schemas Pydantic para requests y responses MCP
- Crear SessionManager para gestionar sesiones en memoria
- Agregar property tests para validación de ProviderConfig y SessionConfig
- Actualizar design.md con nueva estructura de respuesta simplificada para agentes AI

## Changes
- `app/schemas/mcp_request.py` - Schemas para request MCP
- `app/schemas/mcp_response.py` - Schemas para response (ItemResponse, ToolCallResponse)
- `app/schemas/errors.py` - ErrorResponse
- `app/schemas/__init__.py` - Exports actualizados
- `app/session.py` - SessionManager con validación
- `tests/property/test_properties_validation.py` - Property tests
- `.kiro/specs/contextforge/design.md` - Documentación actualizada

## Verification
- ✅ Lint: passed
- ✅ Typecheck: passed
- ✅ Tests: 31 passed

## Links
- YouTrack: https://communities.youtrack.cloud/agiles/195-1/current