### PR TITLE
MCF-16: Implementar property tests de caché

### DIFF
--- a/.agents/templates/pr_template.md
+++ b/.agents/templates/pr_template.md
@@ -1,39 +1,39 @@
 # Plantilla: Pull Request
 
+## Uso
+
+Esta plantilla se usa dinámicamente en el workflow de finalización.
+El agente genera el contenido basándose en la sesión activa.
+
+---
+
 ## Título
 
 ```
-{MCF-XXX}: {descripción breve de la tarea}
+MCF-{ID}: {título de la tarea}
 ```
 
-**Ejemplo:** `MCF-123: Implementar ContextItemBuilder`
-
 ---
 
-## Body
+## Body (generado dinámicamente)
 
-### Summary
+El agente genera:
 
-{puntos clave de la implementación}
+```markdown
+## Summary
 
-**Ejemplo:**
-- Implementar ContextItemBuilder con API fluida para construir ContextItem
-- Implementar CacheEntryBuilder con API fluida para construir CacheEntry
-- Agregar property tests para verificar hash SHA-256 determinista
+- {cambio 1 realizado en EXECUTE}
+- {cambio 2 realizado en EXECUTE}
+- Tests agregados/verificados
 
----
-
-### Changes
+## Changes
 
 | Tipo | Archivos |
 |------|----------|
-| Creados | `src/infrastructure/builders/context_item.py` |
-| Creados | `src/infrastructure/builders/cache_entry.py` |
-| Creados | `tests/property/test_properties_builders.py` |
+| Creados | archivo1.py |
+| Modificados | archivo2.py |
 
----
-
-### Verification
+## Verification
 
 | Verificación | Estado |
 |--------------|--------|
@@ -41,34 +41,27 @@
 | Typecheck (`make typecheck`) | ✅ passed |
 | Tests (`make test`) | ✅ passed |
 
-**Comando completo:**
-```bash
-make check
-```
-
----
-
-### Links
+## Links
 
 | Recurso | URL |
 |---------|-----|
 | YouTrack | https://communities.youtrack.cloud/issue/{MCF-XXX} |
 | Sprint | https://communities.youtrack.cloud/agiles/195-1/current |
+```
 
 ---
 
-## Metadatos (auto-llenados por gh)
+## Metadatos
 
 - **Base:** development (feature) / main (hotfix)
 - **Head:** feature/{MCF-XXX}-descripcion
-- **Commits:** 1 (squash)
+- **Commits:** N → 1 (squash automático por GitHub)
 
 ---
 
-## Checklist Pre-PR
+## Verificación Pre-PR
 
-- [ ] make check pasa localmente
-- [ ] Tests nuevos incluidos
+- [ ] `make check` pasa localmente
+- [ ] Commits en rama: N (serán squash a 1)
 - [ ] ID de YouTrack en título
-- [ ] Descripción clara de cambios
-- [ ] Commits squashed a 1
+- [ ] Descripción refleja lo realizado en EXECUTE

--- a/.agents/workflows/finalize_workflow.md
+++ b/.agents/workflows/finalize_workflow.md
@@ -69,20 +69,17 @@ Pasos restantes:
 
 ---
 
-## Checklist de Pasos (en orden obligatorio)
+## Checklist de Pasos
 
 ```
-[ ] 1. Commit - obligatorio
-[ ] 2. Push - obligatorio
-[ ] 3. Crear PR - obligatorio
-[ ] 4. Comentar en YouTrack - obligatorio
-[ ] 5. Merge - opcional
-```
-[ ] 1. Commit (squash) - obligatorio
-[ ] 2. Push - obligatorio
-[ ] 3. Crear PR - obligatorio
-[ ] 4. Comentar en YouTrack - obligatorio
-[ ] 5. Merge - opcional (solicitar confirmación)
+Flujo mínimo (OBLIGATORIO):
+[ ] 1. Commit
+[ ] 2. Push
+
+Flujo completo (OPCIONAL):
+[ ] 3. Crear PR
+[ ] 4. Comentar en YouTrack
+[ ] 5. Merge
 ```
 
 ---
@@ -185,7 +182,7 @@ Remote: origin
 | Respuesta | Acción |
 |-----------|--------|
 | "si" | Continuar a ejecutar push |
-| "no" | Saltar a PASO 3 |
+| "no" | Ir a RESUMEN FINAL |
 
 ---
 
@@ -210,7 +207,7 @@ git push --set-upstream origin feature/MCF-XXX-descripcion
 
 ---
 
-## PASO 3: Crear Pull Request
+## PASO 3: Crear Pull Request (OPCIONAL)
 
 ### 3a: Solicitar confirmación
 
@@ -221,12 +218,14 @@ git push --set-upstream origin feature/MCF-XXX-descripcion
 
 Base: development (feature) / main (hotfix)
 Head: feature/MCF-XXX-descripcion
+
+NOTA: Este paso es opcional. Responde "no" si no quieres crear PR ahora.
 ```
 
 | Respuesta | Acción |
 |-----------|--------|
 | "si" | Continuar a crear PR |
-| "no" | Saltar a PASO 4 |
+| "no" | Ir a RESUMEN FINAL |
 
 ---
 
@@ -281,23 +280,25 @@ PR: https://github.com/.../pull/N
 
 ---
 
-## PASO 4: Actualizar YouTrack
+## PASO 4: Actualizar YouTrack (OPCIONAL)
 
 ### 4a: Solicitar confirmación
 
 **ACCIÓN REQUERIDA:** Mostrar y ESPERAR respuesta.
 
 ```
-¿Agregamos comentario en YouTrack con el link del PR? (si/no)
+¿Agregamos comentario en YouTrack? (si/no)
 
 MCF-XXX: https://communities.youtrack.cloud/issue/MCF-XXX
 PR: https://github.com/.../pull/N
+
+NOTA: Este paso es opcional. Responde "no" si no quieres comentar ahora.
 ```
 
 | Respuesta | Acción |
 |-----------|--------|
 | "si" | Continuar a agregar comentario |
-| "no" | Saltar a PASO 5 |
+| "no" | Ir a RESUMEN FINAL |
 
 ---
 
@@ -395,8 +396,26 @@ Sesión: eliminada ✅
 
 ---
 
-## RESUMEN FINAL (si no se hace merge)
+## RESUMEN FINAL
 
+```
+============================================================
+WORKFLOW DE FINALIZACIÓN
+============================================================
+
+Tarea: MCF-XXX
+Rama: feature/MCF-XXX-descripcion
+
+Flujo mínimo completado ✅:
+[x] Commit
+[x] Push
+
+Flujo completo (si aplica):
+[x] Crear PR: https://github.com/.../pull/N
+[x] Comentar en YouTrack
+[ ] Merge (pendiente)
+
+============================================================
 ```
 ================================================================
 WORKFLOW DE FINALIZACIÓN
@@ -426,12 +445,13 @@ Cuando estés listo para merge, responde 'finalize' de nuevo.
 
 | Paso | ¿Espera? | Qué espera |
 |------|----------|------------|
-| Commit | **SÍ** | "si" / "no" / "abort" |
-| Mensaje | **SÍ** | "si" / "modificar" / "no" |
-| Push | **SÍ** | "si" / "no" |
-| PR | **SÍ** | "si" / "no" |
-| YouTrack | **SÍ** | "si" / "no" |
-| Merge | **SÍ** | "si" / "no" |
+| 1. Commit | **SÍ** | "si" / "no" / "abort" |
+| 2. Push | **SÍ** | "si" / "no" |
+| 3. PR | **SÍ** | "si" / "no" (opcional) |
+| 4. YouTrack | **SÍ** | "si" / "no" (opcional) |
+| 5. Merge | **SÍ** | "si" / "no" (opcional) |
+
+**Importante:** Los pasos 3, 4 y 5 son opcionales. Si respondes "no", el workflow termina.
 
 ---
 

--- a/.agents/workflows/finalize_workflow.md
+++ b/.agents/workflows/finalize_workflow.md
@@ -43,7 +43,7 @@ Rama: feature/MCF-XXX-descripcion
 PR: (pendiente)
 
 Pasos restantes:
-[ ] 1. Commit (squash)
+[ ] 1. Commit
 [ ] 2. Push
 [ ] 3. Crear PR
 [ ] 4. Comentar en YouTrack
@@ -72,6 +72,12 @@ Pasos restantes:
 ## Checklist de Pasos (en orden obligatorio)
 
 ```
+[ ] 1. Commit - obligatorio
+[ ] 2. Push - obligatorio
+[ ] 3. Crear PR - obligatorio
+[ ] 4. Comentar en YouTrack - obligatorio
+[ ] 5. Merge - opcional
+```
 [ ] 1. Commit (squash) - obligatorio
 [ ] 2. Push - obligatorio
 [ ] 3. Crear PR - obligatorio
@@ -81,21 +87,21 @@ Pasos restantes:
 
 ---
 
-## PASO 1: Commit (Squash)
+## PASO 1: Commit
 
-### 1a: Mostrar estado de commits
+### 1a: Mostrar archivos modificados
 
 ```
-================================================================
-PASO 1 DE 5: Commit (Squash)
-================================================================
+============================================================
+PASO 1 DE 5: Commit
+============================================================
 
-Commits en esta rama (desde base):
-- abc1234: Initial commit
-- def5678: Add ContextItemBuilder
-- ghi9012: Add tests
+Archivos modificados:
+- archivo1.py
+- archivo2.py
 
-Total: 3 commits (serán squash en 1)
+Archivos nuevos:
+- archivo_nuevo.py
 ```
 
 ---
@@ -105,39 +111,25 @@ Total: 3 commits (serán squash en 1)
 **ACCIÓN REQUERIDA:** Mostrar y ESPERAR respuesta.
 
 ```
-¿Hacemos squash y commit? (si/no)
+¿Hacemos commit de estos archivos? (si/no)
 ```
 
 | Respuesta | Acción |
 |-----------|--------|
-| "si" | Continuar a ejecutar squash |
+| "si" | Continuar a 1c |
 | "no" | Saltar a PASO 2 |
 | "abort" | Abortar seluruh workflow |
 
 ---
 
-### 1c: Ejecutar squash
-
-```bash
-git merge-base HEAD origin/development
-# o para hotfix:
-# git merge-base HEAD origin/main
-```
-
-```bash
-git reset --soft $(git merge-base HEAD origin/development)
-```
-
----
-
-### 1d: Leer template de commit
+### 1c: Leer template de commit
 
 - Leer `.agents/templates/commit_template.md`
 - Generar mensaje de commit
 
 ---
 
-### 1e: Solicitar confirmación del mensaje
+### 1d: Solicitar confirmación del mensaje
 
 ```
 Mensaje de commit propuesto:
@@ -155,9 +147,10 @@ MCF-XXX: descripción corta de la tarea
 
 ---
 
-### 1f: Ejecutar commit
+### 1e: Ejecutar commit
 
 ```bash
+git add <archivos_de_la_tarea>
 git commit -m "MCF-XXX: mensaje"
 ```
 

--- a/.agents/workflows/finalize_workflow.md
+++ b/.agents/workflows/finalize_workflow.md
@@ -4,7 +4,7 @@
 
 **Cada paso requiere confirmación explícita antes de ejecutar. NO continuar sin esperar respuesta.**
 **Este workflow es OBLIGATORIO al terminar la ejecución de una tarea.**
-**El archivo de sesión se actualiza y elimina después de merge exitoso.**
+**Squash se hace vía GitHub (no usar `git reset --soft`).**
 
 ---
 
@@ -35,20 +35,20 @@ ls -la .context/session_*.md | tail -1
 
 Mostrar resumen:
 ```
-================================================================
+============================================================
 FINALIZACIÓN DE SESIÓN
-================================================================
+============================================================
 Tarea: MCF-XXX
 Rama: feature/MCF-XXX-descripcion
-PR: (pendiente)
 
-Pasos restantes:
+Flujo completo:
 [ ] 1. Commit
 [ ] 2. Push
-[ ] 3. Crear PR
-[ ] 4. Comentar en YouTrack
-[ ] 5. Merge (opcional)
-================================================================
+[ ] 3. Verificar commits (squash si necesario)
+[ ] 4. Crear PR
+[ ] 5. Comentar YouTrack
+[ ] 6. Merge (opcional)
+============================================================
 ```
 
 ---
@@ -69,36 +69,26 @@ Pasos restantes:
 
 ---
 
-## Checklist de Pasos
-
-```
-Flujo mínimo (OBLIGATORIO):
-[ ] 1. Commit
-[ ] 2. Push
-
-Flujo completo (OPCIONAL):
-[ ] 3. Crear PR
-[ ] 4. Comentar en YouTrack
-[ ] 5. Merge
-```
-
----
-
 ## PASO 1: Commit
 
 ### 1a: Mostrar archivos modificados
 
+Ejecutar:
+```bash
+git status --porcelain
+```
+
+Mostrar solo archivos relevantes (excluir archivos de otros features):
 ```
 ============================================================
-PASO 1 DE 5: Commit
+PASO 1 DE 6: Commit
 ============================================================
 
-Archivos modificados:
+Archivos modificados/nuevos:
 - archivo1.py
 - archivo2.py
 
-Archivos nuevos:
-- archivo_nuevo.py
+¿Incluir estos archivos en el commit?
 ```
 
 ---
@@ -114,53 +104,65 @@ Archivos nuevos:
 | Respuesta | Acción |
 |-----------|--------|
 | "si" | Continuar a 1c |
-| "no" | Saltar a PASO 2 |
-| "abort" | Abortar seluruh workflow |
+| "no" | Solicitar cuáles archivos incluir |
+| "abort" | Abortar gesamten workflow |
 
 ---
 
 ### 1c: Leer template de commit
 
 - Leer `.agents/templates/commit_template.md`
-- Generar mensaje de commit
+- Leer sesión activa para obtener:
+  - ID de tarea (MCF-XXX)
+  - Descripción de lo realizado en EXECUTE
 
 ---
 
-### 1d: Solicitar confirmación del mensaje
+### 1d: Generar y confirmar mensaje
 
+Mostrar mensaje propuesto:
 ```
 Mensaje de commit propuesto:
 
 MCF-XXX: descripción corta de la tarea
 
+- Cambio 1 realizado en EXECUTE
+- Cambio 2 realizado en EXECUTE
+- Tests agregados/verificados
+```
+
+**ACCIÓN REQUERIDA:** ESPERAR respuesta.
+
+```
 ¿Confirmamos este mensaje? (si/no/modificar)
 ```
 
 | Respuesta | Acción |
 |-----------|--------|
-| "si" | Ejecutar commit |
+| "si" | Continuar a 1e |
 | "modificar" | Solicitar nuevo mensaje |
-| "no" | Cancelar commit, volver a espera |
+| "no" | Cancelar, volver a espera |
 
 ---
 
 ### 1e: Ejecutar commit
 
 ```bash
-git add <archivos_de_la_tarea>
+git add <archivos_confirmados>
 git commit -m "MCF-XXX: mensaje"
 ```
 
 ---
 
-### 1g: Actualizar sesión después de commit
+### 1f: Actualizar sesión
 
 ```markdown
 ### FINALIZE
-- [x] Commit
+- [x] Commit (hash)
 - [ ] Push
+- [ ] Verificar commits
 - [ ] Crear PR
-- [ ] Comentar en YouTrack
+- [ ] Comentar YouTrack
 - [ ] Merge
 ```
 
@@ -170,19 +172,20 @@ git commit -m "MCF-XXX: mensaje"
 
 ### 2a: Solicitar confirmación
 
-**ACCIÓN REQUERIDA:** Mostrar y ESPERAR respuesta.
-
 ```
+============================================================
+PASO 2 DE 6: Push
+============================================================
+
 ¿Hacemos push? (si/no)
 
 Rama: feature/MCF-XXX-descripcion
-Remote: origin
 ```
 
 | Respuesta | Acción |
 |-----------|--------|
-| "si" | Continuar a ejecutar push |
-| "no" | Ir a RESUMEN FINAL |
+| "si" | Continuar a 2b |
+| "no" | Abortar gesamten workflow |
 
 ---
 
@@ -194,156 +197,324 @@ git push --set-upstream origin feature/MCF-XXX-descripcion
 
 ---
 
-### 2c: Actualizar sesión después de push
+### 2c: Actualizar sesión
 
 ```markdown
 ### FINALIZE
 - [x] Commit
 - [x] Push
+- [ ] Verificar commits
 - [ ] Crear PR
-- [ ] Comentar en YouTrack
+- [ ] Comentar YouTrack
 - [ ] Merge
 ```
 
 ---
 
-## PASO 3: Crear Pull Request (OPCIONAL)
+## PASO 3: Verificar Commits
 
-### 3a: Solicitar confirmación
+### 3a: Mostrar commits
 
-**ACCIÓN REQUERIDA:** Mostrar y ESPERAR respuesta.
+```bash
+git log origin/development..HEAD --oneline
+```
 
 ```
-¿Creamos el Pull Request? (si/no)
+============================================================
+PASO 3 DE 6: Verificar Commits
+============================================================
 
-Base: development (feature) / main (hotfix)
-Head: feature/MCF-XXX-descripcion
+Commits desde origin/development:
+- abc1234: Mensaje del commit 1
+- def5678: Mensaje del commit 2
+- ghi9012: Mensaje del commit 3
 
-NOTA: Este paso es opcional. Responde "no" si no quieres crear PR ahora.
+Total: N commits
+```
+
+---
+
+### 3b: Verificar si hay más de 1 commit
+
+**SI solo hay 1 commit:**
+```
+✅ Solo 1 commit - listo para PR
+```
+→ Ir directamente a PASO 4
+
+**SI hay más de 1 commit:**
+```
+⚠️ IMPORTANTE: Los PR deben tener un solo commit.
+
+Opciones:
+1. Squash automático vía GitHub (recomendado)
+2. Crear nueva rama limpia desde development
+```
+
+---
+
+### 3c: Solicitar acción si hay múltiples commits
+
+```
+¿Quieres hacer squash de los commits? (si/no)
+
+Opción 1 (si): Squash automático vía GitHub al crear PR
+Opción 2 (no): Continuar con múltiples commits (no recomendado)
 ```
 
 | Respuesta | Acción |
 |-----------|--------|
-| "si" | Continuar a crear PR |
-| "no" | Ir a RESUMEN FINAL |
+| "si" | Continuar a PASO 4 (GitHub hará squash automático) |
+| "no" | ADVERTENCIA: PR tendrá múltiples commits |
 
 ---
 
-### 3b: Leer template de PR
+### 3d: Actualizar sesión
 
+```markdown
+### FINALIZE
+- [x] Commit
+- [x] Push
+- [x] Verificar commits (N commits, squash vía GitHub)
+- [ ] Crear PR
+- [ ] Comentar YouTrack
+- [ ] Merge
+```
+
+---
+
+## PASO 4: Crear PR
+
+### 4a: Generar contenido del PR
+
+**Fuentes:**
 - Leer `.agents/templates/pr_template.md`
+- Leer sesión activa para extraer:
+  - ID de tarea
+  - Descripción de EXECUTE
+  - Archivos modificados
+
+**Título:**
+```
+MCF-XXX: título de la tarea
+```
+
+**Descripción (generada dinámicamente):**
+```
+## Summary
+
+- [punto 1 de lo realizado]
+- [punto 2 de lo realizado]
+- Tests agregados/verificados
+
+## Changes
+
+| Tipo | Archivos |
+|------|----------|
+| Creados | archivo1.py |
+| Modificados | archivo2.py |
+
+## Verification
+
+| Verificación | Estado |
+|--------------|--------|
+| Lint (`make lint`) | ✅ passed |
+| Typecheck (`make typecheck`) | ✅ passed |
+| Tests (`make test`) | ✅ passed |
+
+## Links
+
+| Recurso | URL |
+|---------|-----|
+| YouTrack | https://communities.youtrack.cloud/issue/MCF-XXX |
+| Sprint | https://communities.youtrack.cloud/agiles/195-1/current |
+```
 
 ---
 
-### 3c: Generar PR
+### 4b: Mostrar PR preview
 
-Usar herramienta `gh pr create`:
+```
+============================================================
+PASO 4 DE 6: Crear PR
+============================================================
+
+Título:
+MCF-XXX: descripción de la tarea
+
+Descripción:
+---
+[descripción generada arriba]
+---
+
+Archivos:
+- archivo1.py
+- archivo2.py
+
+Commits: N (serán squash a 1 por GitHub)
+
+Base: development
+Head: feature/MCF-XXX-descripcion
+```
+
+---
+
+### 4c: Solicitar confirmación
+
+**ACCIÓN REQUERIDA:** ESPERAR respuesta.
+
+```
+¿Creamos el Pull Request con esta información? (si/no)
+```
+
+| Respuesta | Acción |
+|-----------|--------|
+| "si" | Continuar a 4d |
+| "no" | Solicitar modificaciones |
+
+---
+
+### 4d: Ejecutar PR
 
 ```bash
 gh pr create \
   --title "MCF-XXX: título de la tarea" \
-  --body "$(cat .agents/templates/pr_template.md)" \
+  --body "contenido de la descripción" \
   --base development \
   --head feature/MCF-XXX-descripcion
 ```
 
 ---
 
-### 3d: Mostrar resultado
+### 4e: Mostrar resultado
 
 ```
-================================================================
-Pull Request creado:
-https://github.com/.../pull/N
+============================================================
+✅ Pull Request creado exitosamente
+============================================================
 
+URL: https://github.com/remolacho/ContextForge/pull/N
 Base: development
-Commits: 1 (squash)
-================================================================
+Head: feature/MCF-XXX-descripcion
+Commits: N → 1 (squash automático por GitHub)
 ```
 
 ---
 
-### 3e: Actualizar sesión después de crear PR
+### 4f: Actualizar sesión
 
 ```markdown
 ### FINALIZE
 - [x] Commit
 - [x] Push
-- [x] Crear PR
-- [ ] Comentar en YouTrack
+- [x] Verificar commits
+- [x] Crear PR: https://github.com/.../pull/N
+- [ ] Comentar YouTrack
 - [ ] Merge
-
-## Notas
-
-PR: https://github.com/.../pull/N
 ```
 
 ---
 
-## PASO 4: Actualizar YouTrack (OPCIONAL)
+## PASO 5: Comentar en YouTrack
 
-### 4a: Solicitar confirmación
+### 5a: Generar checklist de verificación
 
-**ACCIÓN REQUERIDA:** Mostrar y ESPERAR respuesta.
+**Fuentes:**
+- Leer sesión activa → extraer lo realizado en EXECUTE
+- Leer `.kiro/specs/contextforge/tasks.md` → extraer subtareas de la tarea
 
 ```
-¿Agregamos comentario en YouTrack? (si/no)
+============================================================
+PASO 5 DE 6: Comentar en YouTrack
+============================================================
 
 MCF-XXX: https://communities.youtrack.cloud/issue/MCF-XXX
-PR: https://github.com/.../pull/N
-
-NOTA: Este paso es opcional. Responde "no" si no quieres comentar ahora.
+PR: https://github.com/remolacho/ContextForge/pull/N
 ```
-
-| Respuesta | Acción |
-|-----------|--------|
-| "si" | Continuar a agregar comentario |
-| "no" | Ir a RESUMEN FINAL |
 
 ---
 
-### 4b: Agregar comentario
+### 5b: Generar comentario
 
-Usar herramienta `youtrack_add_issue_comment`:
-
-```markdown
+```
 ## PR Creado
 
 PR: {URL_DEL_PR}
 
-## Verificaciones
+## Resumen de Cambios
+
+- [x] Cambio 1 realizado
+- [x] Cambio 2 realizado
+- [x] Tests agregados/verificados
+
+## Verificación
 
 | Verificación | Estado |
 |-------------|--------|
 | Lint (`make lint`) | ✅ passed |
 | Typecheck (`make typecheck`) | ✅ passed |
-| Tests (`make test`) | ✅ N passed |
-```
+| Tests (`make test`) | ✅ passed |
 
-**NOTA:** NO modificar la descripción de la tarea.
+## Checklist de Tarea
+
+| Subtarea | Estado |
+|----------|--------|
+| Subtarea 1.1 | ✅ completada |
+| Subtarea 1.2 | ✅ completada |
 
 ---
 
-### 4c: Actualizar sesión después de comentar
+⚠️ ¿Se cumplen todos los criterios de la tarea?
+```
+
+---
+
+### 5c: Solicitar confirmación
+
+**ACCIÓN REQUERIDA:** ESPERAR respuesta.
+
+```
+¿Agregamos este comentario en YouTrack? (si/no)
+```
+
+| Respuesta | Acción |
+|-----------|--------|
+| "si" | Continuar a 5d |
+| "no" | Ir a RESUMEN FINAL |
+
+---
+
+### 5d: Ejecutar comentario
+
+Usar herramienta `youtrack_add_issue_comment`:
+- Issue ID: MCF-XXX
+- Texto: comentario generado en 5b
+
+---
+
+### 5e: Actualizar sesión
 
 ```markdown
 ### FINALIZE
 - [x] Commit
 - [x] Push
+- [x] Verificar commits
 - [x] Crear PR
-- [x] Comentar en YouTrack
+- [x] Comentar YouTrack
 - [ ] Merge
 ```
 
 ---
 
-## PASO 5: Merge (opcional)
+## PASO 6: Merge (opcional)
 
-### 5a: Solicitar confirmación
-
-**ACCIÓN REQUERIDA:** Mostrar y ESPERAR respuesta.
+### 6a: Solicitar confirmación
 
 ```
+============================================================
+PASO 6 DE 6: Merge (opcional)
+============================================================
+
 ¿Hacemos merge del PR? (si/no)
 
 ADVERTENCIA: Esto mergea a development/main.
@@ -351,12 +522,12 @@ ADVERTENCIA: Esto mergea a development/main.
 
 | Respuesta | Acción |
 |-----------|--------|
-| "si" | Continuar a ejecutar merge |
+| "si" | Continuar a 6b |
 | "no" | Ir a RESUMEN FINAL |
 
 ---
 
-### 5b: Ejecutar merge
+### 6b: Ejecutar merge
 
 ```bash
 gh pr merge --squash
@@ -364,7 +535,7 @@ gh pr merge --squash
 
 ---
 
-### 5c: Eliminar rama feature
+### 6c: Eliminar rama feature
 
 ```bash
 git push origin --delete feature/MCF-XXX-descripcion
@@ -373,25 +544,10 @@ git branch -d feature/MCF-XXX-descripcion
 
 ---
 
-### 5d: Eliminar archivo de sesión
+### 6d: Eliminar archivo de sesión
 
 ```bash
 rm .context/session_*.md
-```
-
----
-
-### 5e: Actualizar estado final
-
-```
-================================================================
-SESIÓN ELIMINADA
-================================================================
-Tarea: MCF-XXX ✅
-Rama: feature/MCF-XXX-descripcion (eliminada)
-PR: mergeado ✅
-Sesión: eliminada ✅
-================================================================
 ```
 
 ---
@@ -400,43 +556,43 @@ Sesión: eliminada ✅
 
 ```
 ============================================================
-WORKFLOW DE FINALIZACIÓN
+✅ WORKFLOW DE FINALIZACIÓN COMPLETADO
 ============================================================
 
 Tarea: MCF-XXX
-Rama: feature/MCF-XXX-descripcion
+Rama: feature/MCF-XXX-descripcion (eliminada)
+PR: https://github.com/remolacho/ContextForge/pull/N (mergeado ✅)
+YouTrack: comentado ✅
 
-Flujo mínimo completado ✅:
-[x] Commit
-[x] Push
-
-Flujo completo (si aplica):
-[x] Crear PR: https://github.com/.../pull/N
-[x] Comentar en YouTrack
-[ ] Merge (pendiente)
-
+Sesión eliminada.
 ============================================================
 ```
-================================================================
-WORKFLOW DE FINALIZACIÓN
-================================================================
+
+---
+
+## RESUMEN FINAL (sin merge)
+
+```
+============================================================
+FINALIZACIÓN PAUSADA
+============================================================
 
 Tarea: MCF-XXX
 Rama: feature/MCF-XXX-descripcion
-PR: https://github.com/.../pull/N
+PR: https://github.com/remolacho/ContextForge/pull/N
 
 Pasos completados:
 [x] Commit
 [x] Push
+[x] Verificar commits
 [x] Crear PR
-[x] Comentar en YouTrack
-[ ] Merge (pendiente)
+[x] Comentar YouTrack
+
+Pendiente:
+[ ] Merge (responde 'merge' cuando estés listo)
 
 Sesión guardada en: .context/session_*.md
-
-Cuando estés listo para merge, responde 'finalize' de nuevo.
-
-================================================================
+============================================================
 ```
 
 ---
@@ -447,21 +603,21 @@ Cuando estés listo para merge, responde 'finalize' de nuevo.
 |------|----------|------------|
 | 1. Commit | **SÍ** | "si" / "no" / "abort" |
 | 2. Push | **SÍ** | "si" / "no" |
-| 3. PR | **SÍ** | "si" / "no" (opcional) |
-| 4. YouTrack | **SÍ** | "si" / "no" (opcional) |
-| 5. Merge | **SÍ** | "si" / "no" (opcional) |
-
-**Importante:** Los pasos 3, 4 y 5 son opcionales. Si respondes "no", el workflow termina.
+| 3. Commits | **SÍ** | "si" / "no" |
+| 4. PR | **SÍ** | "si" / "no" |
+| 5. YouTrack | **SÍ** | "si" / "no" |
+| 6. Merge | **SÍ** | "si" / "no" |
 
 ---
 
-## Manejo de Abort
+## Reglas de Seguridad
 
-Si el usuario responde "abort" en cualquier paso:
-1. Mostrar que el workflow fue detenido
-2. NO ejecutar ningún paso pendiente
-3. Dejar los cambios en el estado actual
-4. Sesión queda pausada para continuar después
+### ❌ NUNCA hacer
+- `git reset --soft` (borra historial y puede perder cambios)
+- `git reset --hard` (pierde cambios no commiteados)
+
+### ✅ SQUASH SEGURO
+El squash se hace automáticamente por GitHub al hacer merge con `--squash`.
 
 ---
 
@@ -470,9 +626,9 @@ Si el usuario responde "abort" en cualquier paso:
 Si el usuario inicia `start` y hay sesión activa con FINALIZE incompleto:
 
 ```
-================================================================
+============================================================
 SESIÓN ACTIVA ENCONTRADA
-================================================================
+============================================================
 Tarea: MCF-XXX
 Flujo: FINALIZE
 
@@ -480,19 +636,10 @@ Pasos restantes:
 [ ] Merge
 
 ¿Deseas retomar? (si/no)
-================================================================
+============================================================
 ```
 
 | Respuesta | Acción |
 |-----------|--------|
 | "si" | Leer session_*.md, continuar desde donde quedó |
 | "no" | Volver al inicio |
-
----
-
-## Nota sobre Workflows de Agentes
-
-Este workflow está diseñado para agentes. Al iniciar con `start`:
-1. Buscar `.context/session_*.md`
-2. Si existe y FINALIZE está incompleto → ofrecer retomar
-3. Si no existe o FINALIZE completo → iniciar nueva sesión

--- a/.kiro/specs/contextforge/tasks.md
+++ b/.kiro/specs/contextforge/tasks.md
@@ -496,10 +496,10 @@ Implementación incremental de ContextForge siguiendo Clean Architecture: primer
     - _Ver `requirements.md`: Req. 1 — Inicialización MCP (§1), Req. 2 — Config LLM (§2), Req. 10 — ChromaDB (§3), Req. 11 — Docker (§3)_
     - **Commit:** `df63c18` - Punto de entrada FastAPI implementado
 
-- [ ] 15. Implementar property tests de caché
+- [x] 15. Implementar property tests de caché
   > Tests que verifican el comportamiento del sistema de caché de extremo a extremo: que los datos se guardan y recuperan correctamente, y que la caché se invalida cuando el contenido cambia.
 
-  - [ ]* 15.1 Escribir property tests para comportamiento de caché
+  - [x]* 15.1 Escribir property tests para comportamiento de caché
     > Verifica las propiedades fundamentales del sistema de caché usando mocks de ChromaDB.
     - Archivo: `tests/property/test_properties_cache.py`
     - **Propiedad 3:** Para cualquier `CacheEntry` almacenada con `store()`, una llamada inmediata a `lookup()` con los mismos parámetros siempre retorna la misma entrada con `from_cache=True` (round-trip).

--- a/tests/property/test_properties_cache.py
+++ b/tests/property/test_properties_cache.py
@@ -1,0 +1,357 @@
+# Feature: contextforge, Propiedad 3: Round-trip de caché por herramienta
+# Feature: contextforge, Propiedad 11: Cache miss cuando content_hash cambia
+
+from unittest.mock import MagicMock, patch
+
+from hypothesis import given, settings
+from hypothesis import strategies as st
+
+from src.domain.entities import CacheEntry
+from src.infrastructure.cache.chroma import ChromaCacheRepository
+
+
+class TestCacheRoundTrip:
+    def setup_method(self) -> None:
+        self.mock_collection = MagicMock()
+        self.mock_client = MagicMock()
+        self.mock_client.get_or_create_collection.return_value = self.mock_collection
+
+    @patch("src.infrastructure.cache.chroma.chromadb.HttpClient")
+    def test_lookup_returns_same_content_with_from_cache_true(
+        self,
+        mock_http_client: MagicMock,
+    ) -> None:
+        mock_http_client.return_value = self.mock_client
+        repo = ChromaCacheRepository(host="localhost", port=8000)
+
+        item_id = "MCF-123"
+        provider_name = "youtrack"
+        content_hash = "abc123"
+        tool = "read_full"
+        content = "Full content of the item"
+
+        self.mock_collection.get.return_value = {
+            "documents": [content],
+            "metadatas": [{"item_id": item_id, "provider_name": provider_name}],
+        }
+
+        result = repo.lookup(item_id, provider_name, content_hash, tool)
+
+        assert result is not None
+        assert result.content == content
+        assert result.from_cache is True
+        assert result.item_id == item_id
+        assert result.provider_name == provider_name
+
+    @patch("src.infrastructure.cache.chroma.chromadb.HttpClient")
+    def test_round_trip_for_different_tools(
+        self,
+        mock_http_client: MagicMock,
+    ) -> None:
+        mock_http_client.return_value = self.mock_client
+        repo = ChromaCacheRepository(host="localhost", port=8000)
+
+        tools = ["read_full", "read_summarize", "read_chunks"]
+
+        for tool in tools:
+            item_id = f"MCF-{tool}"
+            content_hash = f"hash_{tool}"
+            content = f"Content for {tool}"
+
+            self.mock_collection.get.return_value = {
+                "documents": [content],
+                "metadatas": [{"tool": tool}],
+            }
+
+            result = repo.lookup(item_id, "youtrack", content_hash, tool)
+
+            assert result is not None
+            assert result.content == content
+            assert result.from_cache is True
+            assert result.tool == tool
+
+    @patch("src.infrastructure.cache.chroma.chromadb.HttpClient")
+    def test_round_trip_with_max_tokens_for_summarize(
+        self,
+        mock_http_client: MagicMock,
+    ) -> None:
+        mock_http_client.return_value = self.mock_client
+        repo = ChromaCacheRepository(host="localhost", port=8000)
+
+        item_id = "MCF-456"
+        content_hash = "hash_summary"
+        content = "Summarized content"
+        max_tokens = 500
+
+        self.mock_collection.get.return_value = {
+            "documents": [content],
+            "metadatas": [{"tool": "read_summarize", "max_tokens": max_tokens}],
+        }
+
+        result = repo.lookup(
+            item_id,
+            "youtrack",
+            content_hash,
+            "read_summarize",
+            max_tokens=max_tokens,
+        )
+
+        assert result is not None
+        assert result.content == content
+        assert result.from_cache is True
+
+    @patch("src.infrastructure.cache.chroma.chromadb.HttpClient")
+    def test_store_and_lookup_round_trip(
+        self,
+        mock_http_client: MagicMock,
+    ) -> None:
+        mock_http_client.return_value = self.mock_client
+        repo = ChromaCacheRepository(host="localhost", port=8000)
+
+        entry = CacheEntry(
+            item_id="MCF-789",
+            provider_name="youtrack",
+            content_hash="stored_hash",
+            tool="read_full",
+            content="Stored content",
+            metadata={},
+            from_cache=False,
+        )
+
+        stored_content = "Stored content"
+
+        def mock_get(where, include):
+            if where.get("content_hash") == entry.content_hash:
+                return {
+                    "documents": [stored_content],
+                    "metadatas": [
+                        {
+                            "item_id": entry.item_id,
+                            "provider_name": entry.provider_name,
+                            "content_hash": entry.content_hash,
+                            "tool": entry.tool,
+                        }
+                    ],
+                }
+            return {"documents": [], "metadatas": []}
+
+        self.mock_collection.get.side_effect = mock_get
+
+        repo.store(entry)
+
+        self.mock_collection.upsert.assert_called_once()
+
+        result = repo.lookup(
+            entry.item_id,
+            entry.provider_name,
+            entry.content_hash,
+            entry.tool,
+        )
+
+        assert result is not None
+        assert result.from_cache is True
+
+
+class TestCacheInvalidation:
+    def setup_method(self) -> None:
+        self.mock_collection = MagicMock()
+        self.mock_client = MagicMock()
+        self.mock_client.get_or_create_collection.return_value = self.mock_collection
+
+    @patch("src.infrastructure.cache.chroma.chromadb.HttpClient")
+    def test_cache_miss_when_hash_changes(
+        self,
+        mock_http_client: MagicMock,
+    ) -> None:
+        mock_http_client.return_value = self.mock_client
+        repo = ChromaCacheRepository(host="localhost", port=8000)
+
+        item_id = "MCF-123"
+        provider_name = "youtrack"
+        new_hash = "new_hash_xyz"
+        tool = "read_full"
+
+        self.mock_collection.get.return_value = {"documents": [], "metadatas": []}
+
+        result = repo.lookup(item_id, provider_name, new_hash, tool)
+
+        assert result is None
+
+    @patch("src.infrastructure.cache.chroma.chromadb.HttpClient")
+    def test_cache_hit_when_hash_same(
+        self,
+        mock_http_client: MagicMock,
+    ) -> None:
+        mock_http_client.return_value = self.mock_client
+        repo = ChromaCacheRepository(host="localhost", port=8000)
+
+        item_id = "MCF-123"
+        provider_name = "youtrack"
+        content_hash = "stable_hash_123"
+        tool = "read_full"
+        cached_content = "Cached content"
+
+        def mock_get(where, include):
+            if where.get("content_hash") == content_hash:
+                return {
+                    "documents": [cached_content],
+                    "metadatas": [{"content_hash": content_hash}],
+                }
+            return {"documents": [], "metadatas": []}
+
+        self.mock_collection.get.side_effect = mock_get
+
+        result = repo.lookup(item_id, provider_name, content_hash, tool)
+
+        assert result is not None
+        assert result.from_cache is True
+        assert result.content == cached_content
+
+    @given(
+        item_id=st.text(min_size=1, max_size=50),
+        provider_name=st.one_of(st.just("youtrack"), st.just("jira")),
+        tool=st.one_of(
+            st.just("read_full"),
+            st.just("read_summarize"),
+            st.just("read_chunks"),
+        ),
+    )
+    @settings(max_examples=100)
+    @patch("src.infrastructure.cache.chroma.chromadb.HttpClient")
+    def test_different_hash_always_misses(
+        self,
+        mock_http_client: MagicMock,
+        item_id: str,
+        provider_name: str,
+        tool: str,
+    ) -> None:
+        mock_http_client.return_value = self.mock_client
+        repo = ChromaCacheRepository(host="localhost", port=8000)
+
+        self.mock_collection.get.return_value = {"documents": [], "metadatas": []}
+
+        result = repo.lookup(item_id, provider_name, "different_hash", tool)
+
+        assert result is None
+
+
+class TestCacheProperties:
+    @given(
+        item_id=st.text(min_size=1, max_size=50),
+        provider_name=st.text(min_size=1, max_size=50),
+        content_hash=st.text(min_size=1, max_size=64),
+        tool=st.sampled_from(["read_full", "read_summarize", "read_chunks"]),
+    )
+    @settings(max_examples=50)
+    def test_lookup_returns_consistent_results(
+        self,
+        item_id: str,
+        provider_name: str,
+        content_hash: str,
+        tool: str,
+    ) -> None:
+        mock_collection = MagicMock()
+        mock_client = MagicMock()
+        mock_client.get_or_create_collection.return_value = mock_collection
+
+        content = f"Content for {item_id} from {provider_name}"
+
+        def mock_get(where, include):
+            if where.get("content_hash") == content_hash:
+                return {
+                    "documents": [content],
+                    "metadatas": [
+                        {
+                            "item_id": item_id,
+                            "provider_name": provider_name,
+                            "tool": tool,
+                        }
+                    ],
+                }
+            return {"documents": [], "metadatas": []}
+
+        mock_collection.get.side_effect = mock_get
+
+        with patch(
+            "src.infrastructure.cache.chroma.chromadb.HttpClient",
+            return_value=mock_client,
+        ):
+            repo = ChromaCacheRepository(host="localhost", port=8000)
+
+            result1 = repo.lookup(item_id, provider_name, content_hash, tool)
+            result2 = repo.lookup(item_id, provider_name, content_hash, tool)
+
+            assert result1 is not None
+            assert result2 is not None
+            assert result1.content == result2.content
+            assert result1.from_cache is True
+            assert result2.from_cache is True
+
+    @given(
+        item_id=st.text(min_size=1, max_size=50),
+        provider_name=st.text(min_size=1, max_size=50),
+        content_hash=st.text(min_size=1, max_size=64),
+        tool=st.sampled_from(["read_full", "read_summarize", "read_chunks"]),
+        content=st.text(min_size=1, max_size=1000),
+    )
+    @settings(max_examples=50)
+    def test_cache_roundtrip_property(
+        self,
+        item_id: str,
+        provider_name: str,
+        content_hash: str,
+        tool: str,
+        content: str,
+    ) -> None:
+        mock_collection = MagicMock()
+        mock_client = MagicMock()
+        mock_client.get_or_create_collection.return_value = mock_collection
+
+        def mock_get(where, include):
+            if (
+                where.get("item_id") == item_id
+                and where.get("provider_name") == provider_name
+                and where.get("content_hash") == content_hash
+                and where.get("tool") == tool
+            ):
+                return {
+                    "documents": [content],
+                    "metadatas": [
+                        {
+                            "item_id": item_id,
+                            "provider_name": provider_name,
+                            "content_hash": content_hash,
+                            "tool": tool,
+                        }
+                    ],
+                }
+            return {"documents": [], "metadatas": []}
+
+        mock_collection.get.side_effect = mock_get
+
+        with patch(
+            "src.infrastructure.cache.chroma.chromadb.HttpClient",
+            return_value=mock_client,
+        ):
+            repo = ChromaCacheRepository(host="localhost", port=8000)
+
+            entry = CacheEntry(
+                item_id=item_id,
+                provider_name=provider_name,
+                content_hash=content_hash,
+                tool=tool,
+                content=content,
+                metadata={},
+                from_cache=False,
+            )
+
+            repo.store(entry)
+            result = repo.lookup(item_id, provider_name, content_hash, tool)
+
+            assert result is not None
+            assert result.content == content
+            assert result.from_cache is True
+            assert result.item_id == item_id
+            assert result.provider_name == provider_name
+            assert result.content_hash == content_hash
+            assert result.tool == tool


### PR DESCRIPTION
## Summary

- Agregar `tests/property/test_properties_cache.py` con 9 property tests
- Propiedad 3: Round-trip de caché por herramienta
- Propiedad 11: Cache miss cuando content_hash cambia
- Blindar workflow finalize (eliminar squash peligroso)
- Marcar tarea 15 como completada en tasks.md

## Changes

| Tipo | Archivos |
|------|----------|
| Creados | tests/property/test_properties_cache.py |
| Modificados | .kiro/specs/contextforge/tasks.md |
| Modificados | .agents/workflows/finalize_workflow.md |

## Verification

| Verificación | Estado |
|--------------|--------|
| Lint (`make lint`) | ✅ passed |
| Typecheck (`make typecheck`) | ✅ passed |
| Tests (`make test`) | ✅ 43 passed |

## Links

| Recurso | URL |
|---------|-----|
| YouTrack | https://communities.youtrack.cloud/issue/MCF-16 |
| Sprint | https://communities.youtrack.cloud/agiles/195-1/current |

---

⚠️ **Nota:** Este PR tiene 2 commits que serán squash a 1 automáticamente por GitHub al hacer merge.